### PR TITLE
Clean up re-running of reco modules

### DIFF
--- a/JetMETCorrections/Type1MET/python/correctionTermsPfMetType1Type2_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsPfMetType1Type2_cff.py
@@ -14,8 +14,7 @@ pfJetsPtrForMetCorr = cms.EDProducer("PFJetFwdPtrProducer",
    src = cms.InputTag("ak4PFJets")
 )
 # this one is needed only if the input file doesn't have it
-# solved automatically with unscheduled execution
-from RecoParticleFlow.PFProducer.pfLinker_cff import particleFlowPtrs
+#from RecoParticleFlow.PFProducer.pfLinker_cff import particleFlowPtrs
 # particleFlowPtrs = cms.EDProducer("PFCandidateFwdPtrProducer",
 #    src = cms.InputTag("particleFlow")
 # )
@@ -67,7 +66,7 @@ corrPfMetType2 = cms.EDProducer(
 ##____________________________________________________________________________||
 correctionTermsPfMetType1Type2 = cms.Sequence(
     pfJetsPtrForMetCorr +
-    particleFlowPtrs +
+    #particleFlowPtrs +
     pfCandsNotInJetsPtrForMetCorr +
     pfCandsNotInJetsForMetCorr +
     pfCandMETcorr +

--- a/PhysicsTools/PatAlgos/python/recoLayer0/pfParticleSelectionForIso_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/pfParticleSelectionForIso_cff.py
@@ -1,12 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-from CommonTools.ParticleFlow.PFBRECO_cff import particleFlowPtrs
 from CommonTools.ParticleFlow.PFBRECO_cff import pfPileUpIsoPFBRECO, pfNoPileUpIsoPFBRECO, pfNoPileUpIsoPFBRECOSequence
 from CommonTools.ParticleFlow.PFBRECO_cff import pfPileUpPFBRECO, pfNoPileUpPFBRECO, pfNoPileUpPFBRECOSequence
 from CommonTools.ParticleFlow.PFBRECO_cff import pfAllNeutralHadronsPFBRECO, pfAllChargedHadronsPFBRECO, pfAllPhotonsPFBRECO, pfAllChargedParticlesPFBRECO, pfPileUpAllChargedParticlesPFBRECO, pfAllNeutralHadronsAndPhotonsPFBRECO, pfSortByTypePFBRECOSequence
 from CommonTools.ParticleFlow.PFBRECO_cff import pfParticleSelectionPFBRECOSequence
 
 pfParticleSelectionForIsoSequence = cms.Sequence(
-    particleFlowPtrs +
     pfParticleSelectionPFBRECOSequence
     )

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -32,7 +32,7 @@ def applySubstructure( process ) :
     ## AK8 groomed masses
     from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSSoftDrop, ak8PFJetsCHSFiltered, ak8PFJetsCHSTrimmed 
     process.ak8PFJetsCHSPruned   = ak8PFJetsCHSPruned.clone()
-    process.ak8PFJetsCHSSoftDrop = ak8PFJetsCHSSoftDrop.clone()
+    #process.ak8PFJetsCHSSoftDrop = ak8PFJetsCHSSoftDrop.clone() # already in AOD
     process.ak8PFJetsCHSTrimmed  = ak8PFJetsCHSTrimmed.clone()
     process.ak8PFJetsCHSFiltered = ak8PFJetsCHSFiltered.clone()
     process.load("RecoJets.JetProducers.ak8PFJetsCHS_groomingValueMaps_cfi")

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -225,11 +225,11 @@ def miniAOD_customizeCommon(process):
     process.slimmedJetsPuppi.packedPFCandidates = cms.InputTag("packedPFCandidates")
 
     ## puppi met
-    process.load('RecoMET.METProducers.PFMET_cfi')
     process.puppiForMET = cms.EDProducer("CandViewMerger",
         src = cms.VInputTag( "pfLeptonsPUPPET", "puppiNoLep")
     )     
-    process.pfMetPuppi = process.pfMet.clone()
+    import RecoMET.METProducers.PFMET_cfi
+    process.pfMetPuppi = RecoMET.METProducers.PFMET_cfi.pfMet.clone()
     process.pfMetPuppi.src = cms.InputTag("puppiForMET")
     process.pfMetPuppi.alias = cms.string('pfMetPuppi')
     ## type1 correction, from puppi jets

--- a/RecoJets/JetProducers/python/ak4PFJetsPuppi_cfi.py
+++ b/RecoJets/JetProducers/python/ak4PFJetsPuppi_cfi.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoJets.JetProducers.PFJetParameters_cfi import *
 from RecoJets.JetProducers.AnomalousCellParameters_cfi import *
-from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
+import RecoJets.JetProducers.ak4PFJets_cfi
 
-ak4PFJetsPuppi = ak4PFJets.clone(
+ak4PFJetsPuppi = RecoJets.JetProducers.ak4PFJets_cfi.ak4PFJets.clone(
     src = cms.InputTag("puppi")
     )
 


### PR DESCRIPTION
- Don't re-run ak4PFJets (fix RecoJets/JetProducers/python/ak4PFJetsPuppi_cfi.py)
- Don'r re-run pfMet
- Don't re-run ak8PFJetsCHSSoftDrop (unless for some reason the code has changed? @ahinzmann )
- Don't re-run particleFlowPtrs (contrarily to popular belief and to what were my expectations, they have been in AOD since a while...)
