### PR TITLE
Make BadGlobalMuonTagger METFilter compliant.

### DIFF
--- a/RecoMET/METFilters/plugins/BadGlobalMuonTagger.cc
+++ b/RecoMET/METFilters/plugins/BadGlobalMuonTagger.cc
@@ -55,6 +55,7 @@ BadGlobalMuonTagger::BadGlobalMuonTagger(const edm::ParameterSet & iConfig) :
     taggingMode_(iConfig.getParameter<bool> ("taggingMode")),
     verbose_(iConfig.getUntrackedParameter<bool> ("verbose",true))
 {
+    produces<bool>();
     produces<edm::PtrVector<reco::Muon>>("bad");
 }
 
@@ -97,7 +98,7 @@ BadGlobalMuonTagger::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
         }
     }
 
-    bool found = false;
+    bool pass = true;
     for (unsigned int i = 0, n = muons.size(); i < n; ++i) {
         if (muons[i].pt() < ptCut_ || goodMuon[i] != 0) continue;
         if (verbose_) printf("potentially bad muon %d of pt %.1f eta %+.3f phi %+.3f\n", int(i+1), muons[i].pt(), muons[i].eta(), muons[i].phi());
@@ -116,13 +117,15 @@ BadGlobalMuonTagger::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
             }
         }
         if (bad) {
-            found = true;
+            pass = false;
             out->push_back(muons.ptrAt(i));
         }
     }
 
+    iEvent.put(std::auto_ptr<bool>(new bool(pass)));
     iEvent.put(std::move(out), "bad");
-    return taggingMode_ || found;
+
+    return taggingMode_ || pass;
 }
 
 


### PR DESCRIPTION
This PR changes the pass/fail logic of the BadGlobalMuonTagger in order be compliant with existing MET filters.

Instead of returning a found decision that denoted the existance of a found bad/duplicate muon, the filter now returns the pass decision. As a result, the module can be added to a sequence or path without sequence negation (~module/module.__invert__).

The module also produces a bool for the pass decision now, that can be evaluated in following analyzers when using the tagging mode with the same recipes as already described here.

Edit: Ok, I just found a HN with an identical proposal -.- ... but at least you might add this with a single click ;)

(note: this is a clone of PR #10 which got corrupted due to a base fork change)