### PR TITLE
More realistic multiplicities for EG emulator in barrel

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
@@ -70,10 +70,10 @@ l1ctLayer1Barrel = cms.EDProducer("L1TCorrelatorLayer1Producer",
         debug = cms.untracked.bool(False)
     ),
     tkEgAlgoParameters=tkEgAlgoParameters.clone(
-        nTRACK = 25,           # to be defined
-        nTRACK_EGIN = 13,          # to be defined
-        nEMCALO_EGIN = 10,  # to be defined
-        nEM_EGOUT = 10,        # to be defined
+        nTRACK = 25,
+        nTRACK_EGIN = 13,
+        nEMCALO_EGIN = 10,
+        nEM_EGOUT = 10,
     ),
     caloSectors = cms.VPSet(
         cms.PSet( 
@@ -165,7 +165,7 @@ l1ctLayer1HGCal = cms.EDProducer("L1TCorrelatorLayer1Producer",
         nTRACK = 30,
         nTRACK_EGIN = 10,
         nEMCALO_EGIN = 10, 
-        nEM_EGOUT = 5, # to be tuned
+        nEM_EGOUT = 5,
         doBremRecovery=True,
         writeEGSta=True),
     caloSectors = _hgcalSectors,
@@ -237,7 +237,7 @@ l1ctLayer1HGCalNoTK = cms.EDProducer("L1TCorrelatorLayer1Producer",
         nTRACK = 30,
         nTRACK_EGIN = 10,
         nEMCALO_EGIN = 10, 
-        nEM_EGOUT = 5, # to be tuned
+        nEM_EGOUT = 5,
         doBremRecovery=True,
         writeEGSta=True),
     caloSectors = _hgcalSectors,

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
@@ -70,10 +70,10 @@ l1ctLayer1Barrel = cms.EDProducer("L1TCorrelatorLayer1Producer",
         debug = cms.untracked.bool(False)
     ),
     tkEgAlgoParameters=tkEgAlgoParameters.clone(
-        nTRACK = 50,           # to be defined
-        nTRACK_EGIN = 50,          # to be defined
-        nEMCALO_EGIN = 50,  # to be defined
-        nEM_EGOUT = 50,        # to be defined
+        nTRACK = 25,           # to be defined
+        nTRACK_EGIN = 13,          # to be defined
+        nEMCALO_EGIN = 10,  # to be defined
+        nEM_EGOUT = 10,        # to be defined
     ),
     caloSectors = cms.VPSet(
         cms.PSet( 


### PR DESCRIPTION
#### PR description:

- set multiplicities of input and output objects for EG barrel emulator as in FW

#### PR validation:
Just checked on double electron sample @ PU. (Would require a test on higher multiplicity signatures)

![canvas(144)](https://user-images.githubusercontent.com/4802196/118985002-5e0f2200-b97e-11eb-8c17-179213025b17.png)

![canvas(149)](https://user-images.githubusercontent.com/4802196/118984879-3ddf6300-b97e-11eb-8d49-205e3540a1a6.png)
![canvas(148)](https://user-images.githubusercontent.com/4802196/118984887-3f109000-b97e-11eb-9aea-2eddca006829.png)
![canvas(147)](https://user-images.githubusercontent.com/4802196/118984889-4041bd00-b97e-11eb-9b74-0956deb85a45.png)
![canvas(146)](https://user-images.githubusercontent.com/4802196/118984890-40da5380-b97e-11eb-941b-ade81f6b8de3.png)



