### PR TITLE
Remove PF EM ID from hwQual of EG objects

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pfeginput_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pfeginput_ref.cpp
@@ -29,7 +29,8 @@ void EGInputSelectorEmulator::select_eginput(const l1ct::HadCaloObjEmu &in,
   out.hwEta = in.hwEta;
   out.hwPhi = in.hwPhi;
   out.hwPtErr = 0;
-  out.hwEmID = in.hwEmID;
+  // shift to get rid of PFEM ID bit (more usable final EG quality)
+  out.hwEmID = (in.hwEmID >> 1);
   valid_out = (in.hwEmID & cfg.idMask) != 0;
 }
 


### PR DESCRIPTION
Change hwQual for EM clusters in interceptor:
the PF EM ID bit is removed from `hwQual` of EG objects with the goal of having an easier mapping of the EG ID.