### PR TITLE
Add support for KBMTF emulation

### DIFF
--- a/DataFormats/L1Scouting/BuildFile.xml
+++ b/DataFormats/L1Scouting/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/NanoAOD"/>
+<use name="DataFormats/L1TMuon"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h
+++ b/DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h
@@ -2,6 +2,7 @@
 #define DataFormats_L1Scouting_L1ScoutingBMTFStub_h
 
 #include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+#include "DataFormats/L1TMuon/interface/L1MuKBMTrack.h"
 
 namespace l1ScoutingRun3 {
 
@@ -54,6 +55,7 @@ namespace l1ScoutingRun3 {
   };
 
   typedef OrbitCollection<BMTFStub> BMTFStubOrbitCollection;
+  typedef OrbitCollection<L1MuKBMTrack> L1MuKBMTrackOrbitCollection;
 
 }  // namespace l1ScoutingRun3
 

--- a/DataFormats/L1Scouting/src/classes.h
+++ b/DataFormats/L1Scouting/src/classes.h
@@ -5,4 +5,5 @@
 #include "DataFormats/L1Scouting/interface/L1ScoutingMuon.h"
 #include "DataFormats/L1Scouting/interface/L1ScoutingCalo.h"
 #include "DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h"
+#include "DataFormats/L1TMuon/interface/L1MuKBMTrack.h"
 #include "DataFormats/L1Scouting/interface/OrbitFlatTable.h"

--- a/DataFormats/L1Scouting/src/classes_def.xml
+++ b/DataFormats/L1Scouting/src/classes_def.xml
@@ -33,6 +33,7 @@
   <class name="std::vector<l1ScoutingRun3::Muon>"/>
   <class name="std::vector<l1ScoutingRun3::Tau>"/>
   
+  <class name="l1ScoutingRun3::L1MuKBMTrackOrbitCollection"/>
   <class name="l1ScoutingRun3::BMTFStubOrbitCollection"/>
   <class name="l1ScoutingRun3::BxSumsOrbitCollection"/>
   <class name="l1ScoutingRun3::EGammaOrbitCollection"/>
@@ -40,6 +41,7 @@
   <class name="l1ScoutingRun3::MuonOrbitCollection"/>
   <class name="l1ScoutingRun3::TauOrbitCollection"/>
 
+  <class name="edm::Wrapper<l1ScoutingRun3::L1MuKBMTrackOrbitCollection>"/>
   <class name="edm::Wrapper<l1ScoutingRun3::BMTFStubOrbitCollection>"/>
   <class name="edm::Wrapper<l1ScoutingRun3::BxSumsOrbitCollection>"/>
   <class name="edm::Wrapper<l1ScoutingRun3::EGammaOrbitCollection>"/>

--- a/L1TriggerScouting/Utilities/BuildFile.xml
+++ b/L1TriggerScouting/Utilities/BuildFile.xml
@@ -1,7 +1,9 @@
 <use name="FWCore/Framework"/>
 <use name="EventFilter/Utilities"/>
+<use name="L1Trigger/L1TMuonBarrel"/>
 <use name="DataFormats/L1Scouting"/>
 <use name="DataFormats/L1Trigger"/>
+<use name="DataFormats/L1TMuon"/>
 <export>
   <lib name="1"/>
 </export>

--- a/L1TriggerScouting/Utilities/plugins/BuildFile.xml
+++ b/L1TriggerScouting/Utilities/plugins/BuildFile.xml
@@ -5,6 +5,10 @@
 <use name="IOPool/Provenance"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/L1Scouting"/>
+<use name="DataFormats/L1TMuon"/>
 <use name="EventFilter/Utilities"/>
+<use name="L1Trigger/L1TMuon"/>
+<use name="L1Trigger/L1TMuonBarrel"/>
 <use name="L1TriggerScouting/Utilities"/>
+
 <flags EDM_PLUGIN="1"/>

--- a/L1TriggerScouting/Utilities/plugins/ConverterScoutingKbmtfTracksToOrbitFlatTable.cc
+++ b/L1TriggerScouting/Utilities/plugins/ConverterScoutingKbmtfTracksToOrbitFlatTable.cc
@@ -1,0 +1,281 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include <fstream>
+#include <memory>
+#include <string>
+#include <cmath>
+#include <cstdint>
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/MessageLogger/interface/MessageDrop.h"
+
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+#include "DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h"
+#include "DataFormats/L1Scouting/interface/OrbitFlatTable.h"
+
+#include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanAlgo.h"
+#include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanTrackFinder.h"
+#include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanStubProcessor.h"
+
+#include "DataFormats/L1TMuon/interface/L1MuKBMTrack.h"
+#include "DataFormats/L1TMuon/interface/L1MuKBMTCombinedStub.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
+
+#include "CondFormats/L1TObjects/interface/L1TMuonGlobalParams.h"
+#include "CondFormats/DataRecord/interface/L1TMuonGlobalParamsRcd.h"
+#include "L1Trigger/L1TMuon/interface/L1TMuonGlobalParamsHelper.h"
+#include "L1Trigger/L1TMuon/interface/MicroGMTLUTFactories.h"
+
+#include "L1TriggerScouting/Utilities/interface/convertToL1TFormat.h"
+
+using namespace l1ScoutingRun3;
+
+class ConverterScoutingKbmtfTracksToOrbitFlatTable : public edm::stream::EDProducer<> {
+public:
+  // constructor and destructor
+  explicit ConverterScoutingKbmtfTracksToOrbitFlatTable(const edm::ParameterSet&);
+  ~ConverterScoutingKbmtfTracksToOrbitFlatTable() override;
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
+
+  unsigned calcGlobalPhi(l1t::RegionalMuonCand&);
+
+  // the tokens to access the data
+  edm::EDGetTokenT<L1MuKBMTrackOrbitCollection> src_;
+
+  std::string name_, doc_;
+
+  L1TMuonBarrelKalmanAlgo* algo_;
+
+  bool addStubs_;
+
+  std::shared_ptr<l1t::MicroGMTExtrapolationLUT> m_BEtaExtrapolation_;
+  std::shared_ptr<l1t::MicroGMTExtrapolationLUT> m_BPhiExtrapolation_;
+
+  std::unique_ptr<L1TMuonGlobalParamsHelper> microGMTParamsHelper_;
+  edm::ESGetToken<L1TMuonGlobalParams, L1TMuonGlobalParamsRcd> m_microGMTParamsToken_;
+
+  int fwRev_;
+};
+// -----------------------------------------------------------------------------
+
+// -------------------------------- constructor  -------------------------------
+
+ConverterScoutingKbmtfTracksToOrbitFlatTable::ConverterScoutingKbmtfTracksToOrbitFlatTable(const edm::ParameterSet& iConfig)
+    : src_(consumes<L1MuKBMTrackOrbitCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      name_(iConfig.getParameter<std::string>("name")),
+      doc_(iConfig.getParameter<std::string>("doc")),
+      algo_(new L1TMuonBarrelKalmanAlgo(iConfig.getParameter<edm::ParameterSet>("algoSettings"))),
+      addStubs_(iConfig.getParameter<bool>("addStubs")) {
+  produces<OrbitFlatTable>();
+
+  m_microGMTParamsToken_ = esConsumes<L1TMuonGlobalParams, L1TMuonGlobalParamsRcd, edm::Transition::BeginRun>();
+  microGMTParamsHelper_ = std::make_unique<L1TMuonGlobalParamsHelper>();
+  fwRev_ = 0x8010000;
+}
+// -----------------------------------------------------------------------------
+
+
+ConverterScoutingKbmtfTracksToOrbitFlatTable::~ConverterScoutingKbmtfTracksToOrbitFlatTable() {
+  if (algo_ != nullptr)
+    delete algo_;
+
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+
+// ----------------------- method called for each orbit  -----------------------
+void ConverterScoutingKbmtfTracksToOrbitFlatTable::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<L1MuKBMTrackOrbitCollection> src;
+  iEvent.getByToken(src_, src);
+  auto out = std::make_unique<OrbitFlatTable>(src->bxOffsets(), name_);
+  out->setDoc(doc_);
+
+  int outputShiftPhi = 3;
+  int outputShiftEta = 3;
+  if (fwRev_ >= 0x4010000) {
+    outputShiftPhi = 2;
+    outputShiftEta = 0;
+  }
+
+  std::vector<float> pt(out->size());
+  std::vector<float> eta(out->size());
+  std::vector<float> phi(out->size());
+  std::vector<int16_t> charge(out->size());
+  std::vector<int16_t> quality(out->size());
+  std::vector<int16_t> dxy(out->size());
+  std::vector<int16_t> index(out->size());
+  std::vector<float> ptUnconstrained(out->size());
+  std::vector<float> etaAtVtx(out->size());
+  std::vector<float> phiAtVtx(out->size());
+
+  std::vector<int16_t> nStub(out->size());
+  std::vector<std::vector<int16_t>> sStation(4, std::vector<int16_t>(out->size(), 0));
+  std::vector<std::vector<int16_t>> sSector(4, std::vector<int16_t>(out->size(), 0));
+  std::vector<std::vector<int16_t>> sWheel(4, std::vector<int16_t>(out->size(), 0));
+  std::vector<std::vector<int16_t>> sHwQual(4, std::vector<int16_t>(out->size(), 0));
+  std::vector<std::vector<int16_t>> sHwPhi(4, std::vector<int16_t>(out->size(), 0));
+  std::vector<std::vector<int16_t>> sHwPhiB(4, std::vector<int16_t>(out->size(), 0));
+  std::vector<std::vector<int16_t>> sHwEta1(4, std::vector<int16_t>(out->size(), 0));
+  std::vector<std::vector<int16_t>> sHwQEta1(4, std::vector<int16_t>(out->size(), 0));
+  std::vector<std::vector<int16_t>> sHwEta2(4, std::vector<int16_t>(out->size(), 0));
+  std::vector<std::vector<int16_t>> sHwQEta2(4, std::vector<int16_t>(out->size(), 0));
+  std::vector<std::vector<int16_t>> sTag(4, std::vector<int16_t>(out->size(), 0));
+
+  unsigned int i = 0;
+  for (const L1MuKBMTrack& track : *src) {
+
+    l1t::RegionalMuonCand bmtf_m = algo_->convertToBMTF(track);
+    pt[i] = ugmt::fPt(bmtf_m.hwPt());
+    eta[i] = ugmt::fEta(bmtf_m.hwEta());
+    phi[i] = ugmt::fPhi(calcGlobalPhi(bmtf_m));
+    charge[i] = bmtf_m.hwSign()==1? -1 : 1;
+    quality[i] = bmtf_m.hwQual();
+    dxy[i] = track.dxy();
+    index[i] = bmtf_m.processor(); // wrong for now
+    ptUnconstrained[i] = ugmt::fPtUnconstrained(bmtf_m.hwPtUnconstrained());
+
+    int ptRedInWidth = m_BPhiExtrapolation_->getPtRedInWidth();
+    int ptMask = (1 << ptRedInWidth) - 1;
+    int etaRedInWidth = m_BPhiExtrapolation_->getEtaRedInWidth();
+    int redEtaShift = 8 - etaRedInWidth;
+
+    // only use LSBs of pt:
+    int ptRed = bmtf_m.hwPt() & ptMask;
+    // here we drop the LSBs and mask the MSB
+    int etaAbsRed = (std::abs(bmtf_m.hwEta()) >> redEtaShift) & ((1 << etaRedInWidth) - 1);
+    int deltaPhi = 0;
+    int deltaEta = 0;
+
+    if (bmtf_m.hwPt() < (1 << ptRedInWidth)) {  // extrapolation only for "low" pT muons
+      int sign = 1;
+      if (bmtf_m.hwSign() == 1) {
+        sign = -1;
+      }
+      deltaPhi = (m_BPhiExtrapolation_->lookup(etaAbsRed, ptRed) << outputShiftPhi) * sign;
+      deltaEta = (m_BEtaExtrapolation_->lookup(etaAbsRed, ptRed) << outputShiftEta);
+      if (bmtf_m.hwEta() > 0) {
+        deltaEta *= -1;
+      }
+    }
+
+    etaAtVtx[i] = ugmt::fEta(bmtf_m.hwEta() + deltaEta);
+    phiAtVtx[i] = ugmt::fPhi(calcGlobalPhi(bmtf_m) + deltaPhi);
+
+    if (addStubs_) {
+      nStub[i] = track.stubs().size();
+      unsigned j = 0;
+      for (const auto& stub : track.stubs()) {
+        sStation[j][i] = (*stub).stNum();
+        sSector[j][i] = (*stub).scNum();
+        sWheel[j][i] = (*stub).whNum();
+        sHwQual[j][i] = (*stub).quality();
+        sHwPhi[j][i] = (*stub).phi();
+        sHwPhiB[j][i] = (*stub).phiB();
+        sHwEta1[j][i] = (*stub).eta1();
+        sHwQEta1[j][i] = (*stub).qeta1();
+        sHwEta2[j][i] = (*stub).eta2();
+        sHwQEta2[j][i] = (*stub).qeta2();
+        sTag[j][i] = (*stub).tag();
+        ++j;
+      }
+    }
+
+    ++i;
+  }
+
+  out->addColumn<float>("pt", pt, "pt (physical units)");
+  out->addColumn<float>("eta", eta, "eta at second muon station (physical units)");
+  out->addColumn<float>("phi", phi, "phi at second muon station (physical units)");
+  out->addColumn<int16_t>("hwCharge", charge, "hwCharge (hw units)");
+  out->addColumn<int16_t>("hwQual", quality, "hwQual (hw units)");
+  out->addColumn<int16_t>("hwDXY", dxy, "untruncated transverse impact parameter (hw units)");
+  out->addColumn<int16_t>("processor", index, "processor ([0-11])");
+  out->addColumn<float>("ptUnconstrained", ptUnconstrained, "pt without vertex constraint (physical units)");
+  out->addColumn<float>("etaAtVtx", etaAtVtx, "eta re-extrapolated at vertex (physical units)");
+  out->addColumn<float>("phiAtVtx", phiAtVtx, "phi re-extrapolated at vertex (physical units)");
+
+  if (addStubs_) {
+    out->addColumn<int16_t>("nStub", nStub, "number of stubs used to reconstruct KBMTF track");
+    for (int i=0; i<4; ++i) {
+  	  out->addColumn<int16_t>("s"+std::to_string(i+1)+"Station", sStation[i], "stub station");
+  	  out->addColumn<int16_t>("s"+std::to_string(i+1)+"Sector", sSector[i], "stub sector");
+  	  out->addColumn<int16_t>("s"+std::to_string(i+1)+"Wheel", sWheel[i], "stub wheel");
+  	  out->addColumn<int16_t>("s"+std::to_string(i+1)+"HwQual", sHwQual[i], "stub quality (hw units)");
+  	  out->addColumn<int16_t>("s"+std::to_string(i+1)+"HwPhi", sHwPhi[i], "stub local phi position (hw units)");
+  	  out->addColumn<int16_t>("s"+std::to_string(i+1)+"HwPhiB", sHwPhiB[i], "stub phi bending (hw units)");
+  	  out->addColumn<int16_t>("s"+std::to_string(i+1)+"HwEta1", sHwEta1[i], "eta of first stub in chamber (hw units)");
+  	  out->addColumn<int16_t>("s"+std::to_string(i+1)+"HwQEta1", sHwQEta1[i], "eta quality of first stub in chamber (hw units)");
+  	  out->addColumn<int16_t>("s"+std::to_string(i+1)+"HwEta2", sHwEta2[i], "eta of second stub in chamber (hw units)");
+  	  out->addColumn<int16_t>("s"+std::to_string(i+1)+"HwQEta2", sHwQEta2[i], "eta quality of second stub in chamber (hw units)");
+  	  out->addColumn<int16_t>("s"+std::to_string(i+1)+"Tag", sTag[i], "tag=0 is for second stub in chamber");
+    }
+  }
+
+  iEvent.put(std::move(out));
+}
+
+
+// ------------ method called when starting to processes a run  ------------
+void ConverterScoutingKbmtfTracksToOrbitFlatTable::beginRun(edm::Run const& run, edm::EventSetup const& iSetup) {
+
+  /*
+  edm::ESHandle<L1TMuonGlobalParams> microGMTParamsHandle = iSetup.getHandle(m_microGMTParamsToken);
+
+  std::unique_ptr<L1TMuonGlobalParams_PUBLIC> microGMTParams(
+      new L1TMuonGlobalParams_PUBLIC(cast_to_L1TMuonGlobalParams_PUBLIC(*microGMTParamsHandle.product())));
+  if (microGMTParams->pnodes_.empty()) {
+    edm::ESHandle<L1TMuonGlobalParams> o2oProtoHandle = iSetup.getHandle(m_o2oProtoToken);
+    microGMTParamsHelper = std::make_unique<L1TMuonGlobalParamsHelper>(*o2oProtoHandle.product());
+  } else
+    microGMTParamsHelper =
+        std::make_unique<L1TMuonGlobalParamsHelper>(cast_to_L1TMuonGlobalParams(*microGMTParams.get()));
+  */
+
+  edm::ESHandle<L1TMuonGlobalParams> microGMTParamsHandle_ = iSetup.getHandle(m_microGMTParamsToken_);
+  microGMTParamsHelper_ = std::make_unique<L1TMuonGlobalParamsHelper>(*microGMTParamsHandle_.product());
+  if (!microGMTParamsHelper_) {
+    edm::LogError("L1TMicroGMTLUTDumper") << "Could not retrieve parameters from Event Setup" << std::endl;
+  }
+  
+  // int fwRev_ = 0x8010000; // microGMTParamsHelper_->fwVersion();
+
+  m_BEtaExtrapolation_ = l1t::MicroGMTExtrapolationLUTFactory::create(microGMTParamsHelper_->bEtaExtrapolationLUT(), l1t::MicroGMTConfiguration::ETA_OUT, fwRev_);
+  m_BPhiExtrapolation_ = l1t::MicroGMTExtrapolationLUTFactory::create(microGMTParamsHelper_->bPhiExtrapolationLUT(), l1t::MicroGMTConfiguration::PHI_OUT, fwRev_);
+}
+
+// ------------ method called when ending to processes a run  ------------
+void ConverterScoutingKbmtfTracksToOrbitFlatTable::endRun(edm::Run const&, edm::EventSetup const&) {}
+
+void ConverterScoutingKbmtfTracksToOrbitFlatTable::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+unsigned ConverterScoutingKbmtfTracksToOrbitFlatTable::calcGlobalPhi(l1t::RegionalMuonCand& l1_reg_m) {
+
+  unsigned globalPhi = l1_reg_m.processor()*48 + l1_reg_m.hwPhi();
+  globalPhi += 576 - 24;      // first processor starts at -15degrees in cms phi
+  globalPhi = globalPhi%576;  // wrap around
+
+  return globalPhi;
+}
+
+DEFINE_FWK_MODULE(ConverterScoutingKbmtfTracksToOrbitFlatTable);

--- a/L1TriggerScouting/Utilities/plugins/L1TMuonBarrelScoutingKalmanTrackProducer.cc
+++ b/L1TriggerScouting/Utilities/plugins/L1TMuonBarrelScoutingKalmanTrackProducer.cc
@@ -1,0 +1,223 @@
+#include <memory>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanAlgo.h"
+#include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanTrackFinder.h"
+#include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanStubProcessor.h"
+
+#include "DataFormats/L1TMuon/interface/L1MuKBMTCombinedStub.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
+
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+#include "DataFormats/L1Scouting/interface/L1ScoutingMuon.h"
+#include "DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h"
+
+#include "L1TriggerScouting/Utilities/interface/conversion.h"
+#include "L1TriggerScouting/Utilities/interface/convertToL1TFormat.h"
+
+using namespace l1ScoutingRun3;
+
+//
+// class declaration
+//
+
+class L1TMuonBarrelScoutingKalmanTrackProducer : public edm::stream::EDProducer<> {
+public:
+  explicit L1TMuonBarrelScoutingKalmanTrackProducer(const edm::ParameterSet&);
+  ~L1TMuonBarrelScoutingKalmanTrackProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  unsigned int calcGlobalPhi(const l1t::RegionalMuonCand&);
+  double calcDr(const l1t::RegionalMuonCand&, const l1t::Muon&);
+
+private:
+  void beginStream(edm::StreamID) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
+
+  edm::EDGetTokenT<L1MuKBMTCombinedStubCollection> src_;
+  edm::EDGetTokenT<MuonOrbitCollection> gmtSrc_;
+  L1TMuonBarrelKalmanAlgo* algo_;
+  L1TMuonBarrelKalmanTrackFinder* trackFinder_;
+  bool matchGmt_;
+  double drCut_;
+  double phiMult_;
+  double etaMult_;
+  bool debug_;
+};
+L1TMuonBarrelScoutingKalmanTrackProducer::L1TMuonBarrelScoutingKalmanTrackProducer(const edm::ParameterSet& iConfig)
+    : src_(consumes<L1MuKBMTCombinedStubCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      gmtSrc_(consumes<MuonOrbitCollection>(iConfig.getParameter<edm::InputTag>("gmtSrc"))),
+      algo_(new L1TMuonBarrelKalmanAlgo(iConfig.getParameter<edm::ParameterSet>("algoSettings"))),
+      trackFinder_(new L1TMuonBarrelKalmanTrackFinder(iConfig.getParameter<edm::ParameterSet>("trackFinderSettings"))),
+      matchGmt_(iConfig.getParameter<bool>("matchGmt")),
+      drCut_(iConfig.getParameter<double>("drCut")),
+      phiMult_(iConfig.getParameter<double>("phiMult")),
+      etaMult_(iConfig.getParameter<double>("etaMult")),
+      debug_(iConfig.getParameter<bool>("debug")) {
+  // produces<L1MuKBMTrackBxCollection>("BMTF");
+  produces<L1MuKBMTrackOrbitCollection>("L1MuKBMTrack").setBranchAlias("L1MuKBMTrackOrbitCollection");
+}
+
+L1TMuonBarrelScoutingKalmanTrackProducer::~L1TMuonBarrelScoutingKalmanTrackProducer() {
+  if (algo_ != nullptr)
+    delete algo_;
+
+  if (trackFinder_ != nullptr)
+    delete trackFinder_;
+
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void L1TMuonBarrelScoutingKalmanTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  Handle<L1MuKBMTCombinedStubCollection> stubsCollection;
+  Handle<MuonOrbitCollection> muonsCollection;
+  iEvent.getByToken(src_, stubsCollection);
+  if (matchGmt_) iEvent.getByToken(gmtSrc_, muonsCollection);
+
+  std::vector<int> seenBxs;
+  L1MuKBMTCombinedStubRefVector stubs;
+  for (size_t i=0; i<stubsCollection->size(); ++i) {
+    L1MuKBMTCombinedStubRef r(stubsCollection, i);
+    stubs.push_back(r);
+    seenBxs.push_back((*stubsCollection)[i].bxNum());
+  }
+
+  std::unique_ptr<L1MuKBMTrackOrbitCollection> kbmTrackCollection(new L1MuKBMTrackOrbitCollection);
+  std::vector<std::vector<L1MuKBMTrack>> kbmTrackBuffer(3565);
+  unsigned nKbmTrack = 0;
+
+  std::sort(seenBxs.begin(), seenBxs.end());
+  seenBxs.erase(std::unique(seenBxs.begin(), seenBxs.end()), seenBxs.end());
+
+  double l1dr = 0.0, l1dr_min = 0.0;
+  int l1_match_i = -1, l1_i = -1;
+  // int64_t n_matches = 0;
+  // int64_t n_gmt_m = 0;
+  // double l1_reg_m_physPhi, l1_reg_m_physEta;
+  // double l1_gmt_m_physPhi, l1_gmt_m_physEta;
+
+  for (const auto& bx : seenBxs) {
+    L1MuKBMTrackCollection tmp = trackFinder_->process(algo_, stubs, bx);
+    if (tmp.size()==0) continue;
+
+    if (matchGmt_) {
+      const auto& muons = muonsCollection->bxIterator(bx);
+      for (const auto& muon : muons) {
+        const l1t::Muon gmt_m = getL1TMuon(muon);
+
+        l1dr_min = 100.0;
+        l1_match_i = -1;
+        l1_i = -1;
+        // l1_reg_m_physPhi = -100.0;
+        // l1_gmt_m_physPhi = gmt_m.hwPhi()/phiMult_;
+        // l1_reg_m_physEta = -100.0;
+        // l1_gmt_m_physEta = gmt_m.hwEta()/etaMult_;        
+
+        // barrel gmt muons
+        if ((gmt_m.tfMuonIndex()>=36) && (gmt_m.tfMuonIndex()<=71)) {
+        
+          for (const auto& track : tmp) { // loop over KBMTF tracks in same BX
+            const l1t::RegionalMuonCand bmtf_m = algo_->convertToBMTF(track);
+            ++l1_i;
+            l1dr = calcDr(bmtf_m, gmt_m);
+            if (l1dr < l1dr_min) {
+              l1_match_i = l1_i;
+              l1dr_min = l1dr;
+              // l1_reg_m_physPhi = calcGlobalPhi(bmtf_m)/phiMult_;
+              // l1_reg_m_physEta = bmtf_m.hwEta()/etaMult_;
+            }
+          }
+        }
+
+        if (l1_match_i!=-1) {
+          kbmTrackBuffer[bx].push_back(tmp[l1_match_i]);
+          nKbmTrack++;
+        }
+      }
+    } else {
+      for (const auto& track : tmp) {
+        kbmTrackBuffer[bx].push_back(track);
+        nKbmTrack++;
+      }
+    }
+    // out->push_back(bx, track);
+    // algo_->addBMTFMuon(bx, track, outBMTF);
+  }
+
+  kbmTrackCollection->fillAndClear(kbmTrackBuffer, nKbmTrack);
+  iEvent.put(std::move(kbmTrackCollection), "L1MuKBMTrack");
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void L1TMuonBarrelScoutingKalmanTrackProducer::beginStream(edm::StreamID) {}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void L1TMuonBarrelScoutingKalmanTrackProducer::endStream() {}
+
+void L1TMuonBarrelScoutingKalmanTrackProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+unsigned L1TMuonBarrelScoutingKalmanTrackProducer::calcGlobalPhi(const l1t::RegionalMuonCand& l1_reg_m) {
+
+  unsigned globalPhi = l1_reg_m.processor()*48 + l1_reg_m.hwPhi();
+  globalPhi += 576 - 24;      // first processor starts at -15degrees in cms phi
+  globalPhi = globalPhi%576;  // wrap around
+
+  return globalPhi;
+}
+
+
+
+double L1TMuonBarrelScoutingKalmanTrackProducer::calcDr(const l1t::RegionalMuonCand& l1_reg_m, const l1t::Muon& l1_gmt_m) {
+
+  double l1_reg_m_physPhi = calcGlobalPhi(l1_reg_m)/phiMult_;
+  if (l1_reg_m_physPhi > M_PI) { l1_reg_m_physPhi -= 2*M_PI; }
+
+  double l1_gmt_m_physPhi = l1_gmt_m.hwPhi()/phiMult_;
+  if (l1_gmt_m_physPhi > M_PI) { l1_gmt_m_physPhi -= 2*M_PI; }
+
+  double dphi = abs(l1_reg_m_physPhi - l1_gmt_m_physPhi);
+  if (dphi > M_PI) { dphi = std::abs(dphi - 2*M_PI); }
+
+  double deta = l1_reg_m.hwEta()/etaMult_ - l1_gmt_m.hwEta()/etaMult_;
+
+  double dr = std::sqrt(dphi*dphi + deta*deta);
+
+  if (debug_) {
+    std::cout << "****** dr calc debug ******" << std::endl;
+    std::cout << "l1_reg_m_phi = " << l1_reg_m_physPhi << std::endl;
+    std::cout << "l1_gmt_m_phi = " << l1_gmt_m_physPhi << std::endl;
+    std::cout << "l1_reg_m_eta = " << l1_reg_m.hwEta()/etaMult_ << std::endl;
+    std::cout << "l1_gmt_m_eta = " << l1_gmt_m.hwEta()/etaMult_ << std::endl;
+    std::cout << "dphi         = " << dphi << std::endl;
+    std::cout << "deta         = " << deta << std::endl;
+    std::cout << "dr           = " << dr   << std::endl;
+  }
+
+  return dr;
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TMuonBarrelScoutingKalmanTrackProducer);

--- a/L1TriggerScouting/Utilities/plugins/convertToL1MuKBMTCombinedStub.cc
+++ b/L1TriggerScouting/Utilities/plugins/convertToL1MuKBMTCombinedStub.cc
@@ -1,0 +1,185 @@
+#include <memory>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanAlgo.h"
+#include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanTrackFinder.h"
+#include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanStubProcessor.h"
+#include "DataFormats/L1TMuon/interface/L1MuKBMTCombinedStub.h"
+
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+#include "DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h"
+
+using namespace l1ScoutingRun3;
+
+//
+// class declaration
+//
+
+class convertToL1MuKBMTCombinedStub : public edm::stream::EDProducer<> {
+public:
+  explicit convertToL1MuKBMTCombinedStub(const edm::ParameterSet&);
+  ~convertToL1MuKBMTCombinedStub() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void beginStream(edm::StreamID) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
+
+  int calculateEta(uint i, int wheel, uint sector, uint station);
+  L1MuKBMTCombinedStub buildStub(int wheel, int sector, int station,
+                                 int phi, int phiB, bool tag,
+                                 int eta, int qeta, int bx,
+                                 int quality);
+  L1MuKBMTCombinedStub buildStubNoEta(int wheel, int sector, int station,
+                                      int phi, int phiB, bool tag,
+                                      int bx, int quality);
+
+  edm::EDGetTokenT<BMTFStubOrbitCollection> src_;
+  int bxMin_;
+  int bxMax_;
+  std::vector<int> eta1_;
+  std::vector<int> eta2_;
+  std::vector<int> eta3_;
+  const edm::EDPutTokenT<L1MuKBMTCombinedStubCollection> putToken_;
+};
+convertToL1MuKBMTCombinedStub::convertToL1MuKBMTCombinedStub(const edm::ParameterSet& iConfig)
+    : src_(consumes<BMTFStubOrbitCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      bxMin_(iConfig.getParameter<int>("bxMin")),
+      bxMax_(iConfig.getParameter<int>("bxMax")),
+      eta1_(iConfig.getParameter<std::vector<int>>("cotTheta_1")),
+      eta2_(iConfig.getParameter<std::vector<int>>("cotTheta_2")),
+      eta3_(iConfig.getParameter<std::vector<int>>("cotTheta_3")),
+      putToken_(produces<L1MuKBMTCombinedStubCollection>()) {}
+
+convertToL1MuKBMTCombinedStub::~convertToL1MuKBMTCombinedStub() {}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void convertToL1MuKBMTCombinedStub::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  Handle<BMTFStubOrbitCollection> stubsCollection;
+  iEvent.getByToken(src_, stubsCollection);
+
+  L1MuKBMTCombinedStubCollection kbmtStubs;
+  for (int bx=bxMin_; bx<=bxMax_; ++bx) {
+    const auto& l1dsStubs = stubsCollection->bxIterator(bx);
+    for (const auto& l1dsStub : l1dsStubs) {
+      if (l1dsStub.hwEta()==0) {
+        kbmtStubs.push_back(buildStubNoEta(l1dsStub.wheel(), l1dsStub.sector(), l1dsStub.station(),
+                                           l1dsStub.hwPhi(), l1dsStub.hwPhiB(), l1dsStub.tag(),
+                                           bx, l1dsStub.hwQual()));
+      } else {
+        kbmtStubs.push_back(buildStub(l1dsStub.wheel(), l1dsStub.sector(), l1dsStub.station(),
+                                      l1dsStub.hwPhi(), l1dsStub.hwPhiB(), l1dsStub.tag(),
+                                      l1dsStub.hwEta(), l1dsStub.hwQEta(),
+                                      bx, l1dsStub.hwQual()));
+      }
+    }
+  }
+
+  iEvent.emplace(putToken_, std::move(kbmtStubs));
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void convertToL1MuKBMTCombinedStub::beginStream(edm::StreamID) {}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void convertToL1MuKBMTCombinedStub::endStream() {}
+
+void convertToL1MuKBMTCombinedStub::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+// from Kalman stub producer
+int convertToL1MuKBMTCombinedStub::calculateEta(uint i, int wheel, uint sector, uint station) {
+  int eta = 0;
+  if (wheel > 0) {
+    eta = 7 * wheel + 3 - i;
+  } else if (wheel < 0) {
+    eta = 7 * wheel + i - 3;
+  } else {
+    if (sector == 0 || sector == 3 || sector == 4 || sector == 7 || sector == 8 || sector == 11)
+      eta = i - 3;
+    else
+      eta = 3 - i;
+  }
+
+  if (station == 1)
+    eta = -eta1_[eta + 17];
+  else if (station == 2)
+    eta = -eta2_[eta + 17];
+  else
+    eta = -eta3_[eta + 17];
+
+  return eta;
+}
+
+L1MuKBMTCombinedStub convertToL1MuKBMTCombinedStub::buildStub(int wheel, int sector, int station,
+                                                              int phi, int phiB, bool tag,
+                                                              int eta, int qeta, int bx,
+                                                              int quality) {
+  // convert eta hw values to global units
+  int qeta1 = 0;
+  int qeta2 = 0;
+  int eta1 = 255;
+  int eta2 = 255;
+  int mask = 0;
+
+  bool hasEta = false;
+  for (uint i = 0; i < 7; ++i) {
+    mask = (1<<i);
+    if ((eta & mask) == 0)
+      continue;
+    if (!hasEta) {
+      hasEta = true;
+      eta1 = calculateEta(i, wheel, sector, station);
+      if ((qeta & mask) == 1)
+        qeta1 = 2;
+      else
+        qeta1 = 1;
+    } else {
+      eta2 = calculateEta(i, wheel, sector, station);
+      if ((qeta & mask) == 1)
+        qeta2 = 2;
+      else
+        qeta2 = 1;
+    }
+  }
+
+  // TODO: tag = true is hardcode for now
+  L1MuKBMTCombinedStub stub(wheel, sector, station, phi, phiB, tag, bx, quality, eta1, eta2, qeta1, qeta2);
+
+  return stub;
+}
+
+L1MuKBMTCombinedStub convertToL1MuKBMTCombinedStub::buildStubNoEta(int wheel, int sector, int station,
+                                                                   int phi, int phiB, bool tag,
+                                                                   int bx, int quality) {
+
+  int qeta1 = 0;
+  int qeta2 = 0;
+  int eta1 = 7;
+  int eta2 = 7;
+  L1MuKBMTCombinedStub stub(wheel, sector, station, phi, phiB, tag, bx, quality, eta1, eta2, qeta1, qeta2);
+
+  return stub;
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(convertToL1MuKBMTCombinedStub);

--- a/L1TriggerScouting/Utilities/python/L1TMuonBarrelScoutingKalmanTrackProducer_cfg.py
+++ b/L1TriggerScouting/Utilities/python/L1TMuonBarrelScoutingKalmanTrackProducer_cfg.py
@@ -1,0 +1,158 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
+import math
+
+options = VarParsing.VarParsing('analysis')
+
+options.register('numThreads',
+                 1, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,          # string, int, or float
+                 "Number of CMSSW threads")
+
+options.register('numFwkStreams',
+                 0, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,          # string, int, or float
+                 "Number of CMSSW streams")
+
+options.register('numOrbits',
+                 -1, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,          # string, int, or float
+                 "Maximum number of orbits to process")
+
+options.parseArguments()
+
+process = cms.Process("KBMTF", run3_2024_L1T)
+
+
+process.maxEvents = cms.untracked.PSet(
+  input = cms.untracked.int32(options.numOrbits)
+)
+
+process.options = cms.untracked.PSet(
+  numberOfThreads = cms.untracked.uint32(options.numThreads),
+  numberOfStreams = cms.untracked.uint32(options.numFwkStreams),
+  numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1) # ShmStreamConsumer requires synchronization at LuminosityBlock boundaries
+)
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = "DEBUG"
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
+# process.Timing = cms.Service("Timing",
+#   summaryOnly = cms.untracked.bool(False),
+#   useJobReport = cms.untracked.bool(True)
+# )
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring(options.inputFiles)
+)
+
+bmtfKalmanTrackingSettings = cms.PSet(
+  verbose = cms.bool(False),  #
+  lutFile = cms.string("L1Trigger/L1TMuon/data/bmtf_luts/kalmanLUTs_v302.root"),
+  initialK = cms.vdouble(-1.196,-1.581,-2.133,-2.263),
+  initialK2 = cms.vdouble(-3.26e-4,-7.165e-4,2.305e-3,-5.63e-3),
+#  eLoss = cms.vdouble(-2.85e-4,-6.21e-5,-1.26e-4,-1.23e-4),
+  eLoss = cms.vdouble(+0.000765,0,0,0),
+
+  aPhi = cms.vdouble(1.942, .01511, .01476, .009799),
+  aPhiB = cms.vdouble(-1.508,-0.1237,-0.1496,-0.1333),
+  aPhiBNLO = cms.vdouble(0.000331,0,0,0),
+
+  bPhi = cms.vdouble(-1,.18245,.20898,.17286),
+  bPhiB = cms.vdouble(-1,1.18245,1.20898,1.17286),
+  phiAt2 = cms.double(0.15918),
+  etaLUT0 = cms.vdouble(8.946,7.508,6.279,6.399),
+  etaLUT1 = cms.vdouble(0.159,0.116,0.088,0.128),
+  #generic cuts
+  chiSquare = cms.vdouble(0.0,0.109375,0.234375,0.359375),
+  chiSquareCutPattern = cms.vint32(7,11,13,14,15),
+  chiSquareCutCurvMax = cms.vint32(2500,2500,2500,2500,2500),
+  chiSquareCut = cms.vint32(126,126,126,126,126),
+
+
+  #vertex cuts
+  trackComp = cms.vdouble(1.75,1.25,0.625,0.250),
+  trackCompErr1 = cms.vdouble(2.0,2.0,2.0,2.0),
+  trackCompErr2 = cms.vdouble(0.218750,0.218750,0.218750,0.3125),
+  trackCompCutPattern = cms.vint32(3,5,6,9,10,12),
+  trackCompCutCurvMax = cms.vint32(34,34,34,34,34,34),   #this is shifted<<4
+  trackCompCut        = cms.vint32(15,15,15,15,15,15),
+  chiSquareCutTight   = cms.vint32(40,126,60,126,126,126),
+
+  combos4=cms.vint32(9,10,11,12,13,14,15),
+  combos3=cms.vint32(5,6,7),
+  combos2=cms.vint32(3),
+  combos1=cms.vint32(), #for future possible usage
+
+  useOfflineAlgo = cms.bool(False),
+  ###Only for the offline algo -not in firmware --------------------
+  mScatteringPhi = cms.vdouble(2.49e-3,5.47e-5,3.49e-5,1.37e-5),
+  mScatteringPhiB = cms.vdouble(7.22e-3,3.461e-3,4.447e-3,4.12e-3),
+  pointResolutionPhi = cms.double(1.),
+  pointResolutionPhiB = cms.double(500.),
+  pointResolutionPhiBH = cms.vdouble(151., 173., 155., 153.),
+  pointResolutionPhiBL = cms.vdouble(17866., 19306., 23984., 23746.),
+  pointResolutionVertex = cms.double(1.),
+
+  useNewQualityCalculation = cms.bool(False),
+)
+
+run3_2024_L1T.toModify(
+  bmtfKalmanTrackingSettings,
+  useNewQualityCalculation = cms.bool(True),
+)
+
+process.kbmtfConvert = cms.EDProducer("convertToL1MuKBMTCombinedStub",
+  src = cms.InputTag("l1ScBMTFUnpacker", "BMTFStub", "SCHLP"),
+  bxMin = cms.int32(1),
+  bxMax = cms.int32(3564),
+  cotTheta_1 = cms.vint32(105,101,97,93,88,84,79,69,64,58,52,46,40,34,21,14,7,0,-7,-14,-21,-34,-40,-46,-52,-58,-64,-69,-79,-84,-88,-93,-97,-101,-105),
+  cotTheta_2 = cms.vint32(93,89,85,81,77,73,68,60,55,50,45,40,34,29,17,12,6,0,-6,-12,-17,-29,-34,-40,-45,-50,-55,-60,-68,-73,-77,-81,-85,-89,-93),
+  cotTheta_3 = cms.vint32(81,77,74,70,66,62,58,51,46,42,38,33,29,24,15,10,5,0,-5,-10,-15,-24,-29,-33,-38,-42,-46,-51,-58,-62,-66,-70,-74,-77,-81),
+  debug = cms.bool(False)
+)
+
+process.kbmtfEmulation = cms.EDProducer("L1TMuonBarrelScoutingKalmanTrackProducer",
+  src = cms.InputTag("kbmtfConvert"),
+  algoSettings = bmtfKalmanTrackingSettings,
+  trackFinderSettings = cms.PSet(
+    sectorsToProcess = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11),
+    verbose = cms.int32(0),
+    sectorSettings = cms.PSet(
+      # verbose = cms.int32(1),
+      verbose = cms.int32(0),
+      wheelsToProcess = cms.vint32(-2,-1,0,1,2),
+      regionSettings = cms.PSet(
+        verbose=cms.int32(0)
+      )
+    )
+  ),
+  gmtSrc = cms.InputTag("l1ScGmtUnpacker", "Muon", "SCHLP"),
+  matchGmt = cms.bool(True),
+  drCut = cms.double(0.1),
+  phiMult = cms.double(576./(2*math.pi)),
+  etaMult = cms.double(1./0.010875),
+  debug = cms.bool(False)
+)
+
+process.output = cms.OutputModule("PoolOutputModule",
+  fileName = cms.untracked.string(options.outputFile),
+  outputCommands = cms.untracked.vstring(
+    "keep *",
+    # "keep *_CaloUnpacker_*_*",
+    # "keep *_*_BMTF_*"
+  ),
+  #compressionLevel = cms.untracked.int32(1)
+)
+
+
+process.p1 = cms.Path(process.kbmtfConvert+process.kbmtfEmulation)
+
+process.ep = cms.EndPath(
+  process.output
+)

--- a/L1TriggerScouting/Utilities/python/kbmtFlatTableProducer_cfg.py
+++ b/L1TriggerScouting/Utilities/python/kbmtFlatTableProducer_cfg.py
@@ -1,0 +1,260 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
+import math
+
+options = VarParsing.VarParsing ('analysis')
+
+selbx = "DoubleMuPt0Qual8"
+
+options.parseArguments()
+
+process = cms.Process( "DUMP", run3_2024_L1T )
+
+
+process.maxEvents = cms.untracked.PSet(
+  input = cms.untracked.int32(-1)
+)
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
+
+process.load('L1Trigger.L1TMuon.fakeGmtParams_cff')
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring(options.inputFiles)
+)
+
+
+
+
+bmtfKalmanTrackingSettings = cms.PSet(
+  verbose = cms.bool(False),  #
+  lutFile = cms.string("L1Trigger/L1TMuon/data/bmtf_luts/kalmanLUTs_v302.root"),
+  initialK = cms.vdouble(-1.196,-1.581,-2.133,-2.263),
+  initialK2 = cms.vdouble(-3.26e-4,-7.165e-4,2.305e-3,-5.63e-3),
+#  eLoss = cms.vdouble(-2.85e-4,-6.21e-5,-1.26e-4,-1.23e-4),
+  eLoss = cms.vdouble(+0.000765,0,0,0),
+
+  aPhi = cms.vdouble(1.942, .01511, .01476, .009799),
+  aPhiB = cms.vdouble(-1.508,-0.1237,-0.1496,-0.1333),
+  aPhiBNLO = cms.vdouble(0.000331,0,0,0),
+
+  bPhi = cms.vdouble(-1,.18245,.20898,.17286),
+  bPhiB = cms.vdouble(-1,1.18245,1.20898,1.17286),
+  phiAt2 = cms.double(0.15918),
+  etaLUT0 = cms.vdouble(8.946,7.508,6.279,6.399),
+  etaLUT1 = cms.vdouble(0.159,0.116,0.088,0.128),
+  #generic cuts
+  chiSquare = cms.vdouble(0.0,0.109375,0.234375,0.359375),
+  chiSquareCutPattern = cms.vint32(7,11,13,14,15),
+  chiSquareCutCurvMax = cms.vint32(2500,2500,2500,2500,2500),
+  chiSquareCut = cms.vint32(126,126,126,126,126),
+
+
+  #vertex cuts
+  trackComp = cms.vdouble(1.75,1.25,0.625,0.250),
+  trackCompErr1 = cms.vdouble(2.0,2.0,2.0,2.0),
+  trackCompErr2 = cms.vdouble(0.218750,0.218750,0.218750,0.3125),
+  trackCompCutPattern = cms.vint32(3,5,6,9,10,12),
+  trackCompCutCurvMax = cms.vint32(34,34,34,34,34,34),   #this is shifted<<4
+  trackCompCut        = cms.vint32(15,15,15,15,15,15),
+  chiSquareCutTight   = cms.vint32(40,126,60,126,126,126),
+
+  combos4=cms.vint32(9,10,11,12,13,14,15),
+  combos3=cms.vint32(5,6,7),
+  combos2=cms.vint32(3),
+  combos1=cms.vint32(), #for future possible usage
+
+  useOfflineAlgo = cms.bool(False),
+  ###Only for the offline algo -not in firmware --------------------
+  mScatteringPhi = cms.vdouble(2.49e-3,5.47e-5,3.49e-5,1.37e-5),
+  mScatteringPhiB = cms.vdouble(7.22e-3,3.461e-3,4.447e-3,4.12e-3),
+  pointResolutionPhi = cms.double(1.),
+  pointResolutionPhiB = cms.double(500.),
+  pointResolutionPhiBH = cms.vdouble(151., 173., 155., 153.),
+  pointResolutionPhiBL = cms.vdouble(17866., 19306., 23984., 23746.),
+  pointResolutionVertex = cms.double(1.),
+
+  useNewQualityCalculation = cms.bool(False),
+)
+
+bmtfKalmanTrackingOfflineSettings = cms.PSet(
+  verbose = cms.bool(False),  #
+  lutFile = cms.string("L1Trigger/L1TMuon/data/bmtf_luts/kalmanLUTs_v302.root"),
+  initialK = cms.vdouble(-1.196,-1.581,-2.133,-2.263),
+  initialK2 = cms.vdouble(-3.26e-4,-7.165e-4,2.305e-3,-5.63e-3),
+#  eLoss = cms.vdouble(-2.85e-4,-6.21e-5,-1.26e-4,-1.23e-4),
+  eLoss = cms.vdouble(+0.000765,0,0,0),
+
+  aPhi = cms.vdouble(1.942, .01511, .01476, .009799),
+  aPhiB = cms.vdouble(-1.508,-0.1237,-0.1496,-0.1333),
+  aPhiBNLO = cms.vdouble(0.000331,0,0,0),
+
+  bPhi = cms.vdouble(-1,.18245,.20898,.17286),
+  bPhiB = cms.vdouble(-1,1.18245,1.20898,1.17286),
+  phiAt2 = cms.double(0.15918),
+  etaLUT0 = cms.vdouble(8.946,7.508,6.279,6.399),
+  etaLUT1 = cms.vdouble(0.159,0.116,0.088,0.128),
+  #generic cuts
+  chiSquare = cms.vdouble(0.0,0.109375,0.234375,0.359375),
+  chiSquareCutPattern = cms.vint32(7,11,13,14,15),
+  chiSquareCutCurvMax = cms.vint32(2500,2500,2500,2500,2500),
+  chiSquareCut = cms.vint32(126,126,126,126,126),
+
+  #vertex cuts
+  trackComp = cms.vdouble(1.75,1.25,0.625,0.250),
+  trackCompErr1 = cms.vdouble(2.0,2.0,2.0,2.0),
+  trackCompErr2 = cms.vdouble(0.218750,0.218750,0.218750,0.3125),
+  trackCompCutPattern = cms.vint32(3,5,6,9,10,12),
+  trackCompCutCurvMax = cms.vint32(34,34,34,34,34,34),   #this is shifted<<4
+  trackCompCut        = cms.vint32(15,15,15,15,15,15),
+  chiSquareCutTight   = cms.vint32(40,126,60,126,126,126),
+
+  combos4=cms.vint32(9,10,11,12,13,14,15),
+  combos3=cms.vint32(5,6,7),
+  combos2=cms.vint32(3),
+  combos1=cms.vint32(), #for future possible usage
+
+  useOfflineAlgo = cms.bool(True),
+  ###Only for the offline algo -not in firmware --------------------
+  mScatteringPhi = cms.vdouble(2.49e-3,5.47e-5,3.49e-5,1.37e-5),
+  mScatteringPhiB = cms.vdouble(7.22e-3,3.461e-3,4.447e-3,4.12e-3),
+  pointResolutionPhi = cms.double(1.),
+  pointResolutionPhiB = cms.double(500.),
+  pointResolutionPhiBH = cms.vdouble(151., 173., 155., 153.),
+  pointResolutionPhiBL = cms.vdouble(17866., 19306., 23984., 23746.),
+  pointResolutionVertex = cms.double(1.),
+
+  useNewQualityCalculation = cms.bool(False),
+)
+
+run3_2024_L1T.toModify(
+  bmtfKalmanTrackingSettings,
+  useNewQualityCalculation = cms.bool(True),
+)
+
+run3_2024_L1T.toModify(
+  bmtfKalmanTrackingOfflineSettings,
+  useNewQualityCalculation = cms.bool(True),
+)
+
+process.kbmtfConvert = cms.EDProducer("convertToL1MuKBMTCombinedStub",
+  src = cms.InputTag("FinalBxSelectorBMTFStub" if selbx else "l1ScBMTFUnpacker", "BMTFStub", "SCHLP"),
+  bxMin = cms.int32(1),
+  bxMax = cms.int32(3564),
+  cotTheta_1 = cms.vint32(105,101,97,93,88,84,79,69,64,58,52,46,40,34,21,14,7,0,-7,-14,-21,-34,-40,-46,-52,-58,-64,-69,-79,-84,-88,-93,-97,-101,-105),
+  cotTheta_2 = cms.vint32(93,89,85,81,77,73,68,60,55,50,45,40,34,29,17,12,6,0,-6,-12,-17,-29,-34,-40,-45,-50,-55,-60,-68,-73,-77,-81,-85,-89,-93),
+  cotTheta_3 = cms.vint32(81,77,74,70,66,62,58,51,46,42,38,33,29,24,15,10,5,0,-5,-10,-15,-24,-29,-33,-38,-42,-46,-51,-58,-62,-66,-70,-74,-77,-81),
+  debug = cms.bool(False)
+)
+
+process.kbmtfEmulation = cms.EDProducer("L1TMuonBarrelScoutingKalmanTrackProducer",
+  src = cms.InputTag("kbmtfConvert"),
+  algoSettings = bmtfKalmanTrackingSettings,
+  trackFinderSettings = cms.PSet(
+    sectorsToProcess = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11),
+    verbose = cms.int32(0),
+    sectorSettings = cms.PSet(
+      # verbose = cms.int32(1),
+      verbose = cms.int32(0),
+      wheelsToProcess = cms.vint32(-2,-1,0,1,2),
+      regionSettings = cms.PSet(
+        verbose=cms.int32(0)
+      )
+    )
+  ),
+  gmtSrc = cms.InputTag("FinalBxSelectorMuon" if selbx else "l1ScGmtUnpacker", "Muon"),
+  matchGmt = cms.bool(True),
+  drCut = cms.double(0.1),
+  phiMult = cms.double(576./(2*math.pi)),
+  etaMult = cms.double(1./0.010875),
+  debug = cms.bool(False)
+)
+
+process.kbmtfOfflineEmulation = cms.EDProducer("L1TMuonBarrelScoutingKalmanTrackProducer",
+  src = cms.InputTag("kbmtfConvert"),
+  algoSettings = bmtfKalmanTrackingOfflineSettings,
+  trackFinderSettings = cms.PSet(
+    sectorsToProcess = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11),
+    verbose = cms.int32(0),
+    sectorSettings = cms.PSet(
+      # verbose = cms.int32(1),
+      verbose = cms.int32(0),
+      wheelsToProcess = cms.vint32(-2,-1,0,1,2),
+      regionSettings = cms.PSet(
+        verbose=cms.int32(0)
+      )
+    )
+  ),
+  gmtSrc = cms.InputTag("FinalBxSelectorMuon" if selbx else "l1ScGmtUnpacker", "Muon"),
+  matchGmt = cms.bool(True),
+  drCut = cms.double(0.1),
+  phiMult = cms.double(576./(2*math.pi)),
+  etaMult = cms.double(1./0.010875),
+  debug = cms.bool(False)
+)
+
+
+
+
+
+process.scMuonTable = cms.EDProducer("ConvertScoutingMuonsToOrbitFlatTable",
+  src = cms.InputTag("FinalBxSelectorMuon" if selbx else "l1ScGmtUnpacker", "Muon"),
+  name = cms.string("L1Mu"),
+  doc = cms.string("Muons from GMT"),
+)
+process.scKbmtfTable = cms.EDProducer("ConverterScoutingKbmtfTracksToOrbitFlatTable",
+  src = cms.InputTag("kbmtfEmulation", "L1MuKBMTrack"),
+  name = cms.string("L1KBMTF"),
+  doc = cms.string("Re-emulated KBMTF muons"),
+  algoSettings = bmtfKalmanTrackingSettings,
+  addStubs = cms.bool(True)
+)
+process.scKbmtfOfflineTable = cms.EDProducer("ConverterScoutingKbmtfTracksToOrbitFlatTable",
+  src = cms.InputTag("kbmtfOfflineEmulation", "L1MuKBMTrack"),
+  name = cms.string("L1KBMTFOff"),
+  doc = cms.string("Re-emulated KBMTF muons with offline propagation"),
+  algoSettings = bmtfKalmanTrackingOfflineSettings,
+  addStubs = cms.bool(True)
+)
+
+process.p = cms.Path(
+  process.scMuonTable +
+  # process.scKbmtfTable
+  #process.scJetTable +
+  #process.scEgammaTable +
+  #process.scTauTable +
+  # process.scStubsTable +
+  process.kbmtfConvert +
+  process.kbmtfEmulation +
+  process.kbmtfOfflineEmulation +
+  process.scKbmtfTable +
+  process.scKbmtfOfflineTable
+  #process.scSumTable
+)
+
+# process.p.replace(process.scKbmtfTable, process.kbmtfConvert + process.kbmtfEmulation + process.scKbmtfTable)
+
+process.out = cms.OutputModule("OrbitNanoAODOutputModule",
+    fileName = cms.untracked.string(options.outputFile),
+    skipEmptyBXs = cms.bool(True),
+    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('p')),
+    outputCommands = cms.untracked.vstring("drop *", "keep l1ScoutingRun3OrbitFlatTable_*_*_*"),
+    compressionLevel = cms.untracked.int32(5),
+    compressionAlgorithm = cms.untracked.string("ZSTD"),
+)
+
+if selbx:
+  process.out.outputCommands += [ "keep uints_*_SelBx_*" ]
+  if selbx != "any":
+    process.out.selectedBx = cms.InputTag(selbx, "SelBx")
+    process.out.skipEmptyBXs = False
+  else:
+    process.out.selectedBx = cms.InputTag("FinalBxSelector", "SelBx")
+    process.out.skipEmptyBXs = False
+
+process.o = cms.EndPath(
+  process.out
+)


### PR DESCRIPTION
This PR introduces support for KBMTF emulation starting from l1 scouting scouting stubs.
Codes added:
* converter of scouting stubs to L1MuKBMTCombinedStub, which is the format given in input to the emulator
* KBMTF emulator runner, which puts the output L1MuKBMTrack in an OrbitCollection. It comes with an option to perform matching with GMT muons
* Ntuplizer in OrbitFlatTable, which can also add the stubs that gave the L1MuKBMTrack