### PR TITLE
Phase2 Traker Muon Scouting : Unpaker+Analyzer+FlatTableProducer 

### DIFF
--- a/DataFormats/L1TMuonPhase2/interface/L1ScoutingTrackerMuon.h
+++ b/DataFormats/L1TMuonPhase2/interface/L1ScoutingTrackerMuon.h
@@ -10,11 +10,25 @@ namespace l1Scouting {
   class TrackerMuon {
   public:
     TrackerMuon() {}
-    TrackerMuon(float pt, float eta, float phi, float z0, float d0)
-        : pt_(pt), eta_(eta), phi_(phi), z0_(z0), d0_(d0) {}
-    TrackerMuon(float pt,float eta,float phi, float z0,float d0,int8_t charge,uint8_t quality,float beta,uint8_t isolation)
-        : pt_(pt), eta_(eta), phi_(phi), z0_(z0), d0_(d0) , charge_(charge) , quality_(quality), beta_(beta),isolation_(isolation) {}
-        
+    TrackerMuon(float pt, float eta, float phi, float z0, float d0) : pt_(pt), eta_(eta), phi_(phi), z0_(z0), d0_(d0) {}
+    TrackerMuon(float pt,
+                float eta,
+                float phi,
+                float z0,
+                float d0,
+                int8_t charge,
+                uint8_t quality,
+                float beta,
+                uint8_t isolation)
+        : pt_(pt),
+          eta_(eta),
+          phi_(phi),
+          z0_(z0),
+          d0_(d0),
+          charge_(charge),
+          quality_(quality),
+          beta_(beta),
+          isolation_(isolation) {}
 
     float pt() const { return pt_; }
     float eta() const { return eta_; }
@@ -22,7 +36,7 @@ namespace l1Scouting {
     float z0() const { return z0_; }
     float d0() const { return d0_; }
     float beta() const { return beta_; }
-     int8_t charge() const { return charge_; }
+    int8_t charge() const { return charge_; }
     uint8_t quality() const { return quality_; }
     uint8_t isolation() const { return isolation_; }
 
@@ -32,18 +46,17 @@ namespace l1Scouting {
     void setZ0(float z0) { z0_ = z0; }
     void setD0(float d0) { d0_ = d0; }
     void setQuality(uint8_t quality) { quality_ = quality; }
-    float mass() const { return 0.105 ; }
+    float mass() const { return 0.105; }
 
     ROOT::Math::PtEtaPhiMVector p4() const { return ROOT::Math::PtEtaPhiMVector(pt_, eta_, phi_, mass()); }
 
   private:
     float pt_, eta_, phi_, z0_, d0_;
     int8_t charge_;
-    uint8_t  quality_;
+    uint8_t quality_;
     float beta_;
     uint8_t isolation_;
-
   };
-}
+}  // namespace l1Scouting
 
 #endif

--- a/DataFormats/L1TMuonPhase2/interface/L1ScoutingTrackerMuon.h
+++ b/DataFormats/L1TMuonPhase2/interface/L1ScoutingTrackerMuon.h
@@ -1,0 +1,49 @@
+#ifndef DataFormats_L1TParticleFlow_L1ScoutingTrackerMuon_h
+#define DataFormats_L1TParticleFlow_L1ScoutingTrackerMuon_h
+
+#include <vector>
+#include <utility>
+#include <cstdint>
+#include <Math/Vector4D.h>
+
+namespace l1Scouting {
+  class TrackerMuon {
+  public:
+    TrackerMuon() {}
+    TrackerMuon(float pt, float eta, float phi, float z0, float d0)
+        : pt_(pt), eta_(eta), phi_(phi), z0_(z0), d0_(d0) {}
+    TrackerMuon(float pt,float eta,float phi, float z0,float d0,int8_t charge,uint8_t quality,float beta,uint8_t isolation)
+        : pt_(pt), eta_(eta), phi_(phi), z0_(z0), d0_(d0) , charge_(charge) , quality_(quality), beta_(beta),isolation_(isolation) {}
+        
+
+    float pt() const { return pt_; }
+    float eta() const { return eta_; }
+    float phi() const { return phi_; }
+    float z0() const { return z0_; }
+    float d0() const { return d0_; }
+    float beta() const { return beta_; }
+     int8_t charge() const { return charge_; }
+    uint8_t quality() const { return quality_; }
+    uint8_t isolation() const { return isolation_; }
+
+    void setPt(float pt) { pt_ = pt; }
+    void setEta(float eta) { eta_ = eta; }
+    void setPhi(float phi) { phi_ = phi; }
+    void setZ0(float z0) { z0_ = z0; }
+    void setD0(float d0) { d0_ = d0; }
+    void setQuality(uint8_t quality) { quality_ = quality; }
+    float mass() const { return 0.105 ; }
+
+    ROOT::Math::PtEtaPhiMVector p4() const { return ROOT::Math::PtEtaPhiMVector(pt_, eta_, phi_, mass()); }
+
+  private:
+    float pt_, eta_, phi_, z0_, d0_;
+    int8_t charge_;
+    uint8_t  quality_;
+    float beta_;
+    uint8_t isolation_;
+
+  };
+}
+
+#endif

--- a/DataFormats/L1TMuonPhase2/src/L1ScoutingTrackerMuon.cc
+++ b/DataFormats/L1TMuonPhase2/src/L1ScoutingTrackerMuon.cc
@@ -1,0 +1,1 @@
+#include "DataFormats/L1TMuonPhase2/interface/L1ScoutingTrackerMuon.h"

--- a/DataFormats/L1TMuonPhase2/src/classes.h
+++ b/DataFormats/L1TMuonPhase2/src/classes.h
@@ -3,4 +3,6 @@
 #include "DataFormats/L1TMuonPhase2/interface/MuonStub.h"
 #include "DataFormats/L1TMuonPhase2/interface/TrackerMuon.h"
 #include "DataFormats/L1TMuonPhase2/interface/SAMuon.h"
+#include "DataFormats/L1TMuonPhase2/interface/L1ScoutingTrackerMuon.h"
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
 #include <vector>

--- a/DataFormats/L1TMuonPhase2/src/classes_def.xml
+++ b/DataFormats/L1TMuonPhase2/src/classes_def.xml
@@ -16,12 +16,17 @@
  <class name="edm::Wrapper<std::vector<l1t::TrackerMuon > >"/>
  <class name="edm::Ref<l1t::TrackerMuonCollection>" splitLevel="0"/>
  <class name="std::vector<edm::Ref<l1t::TrackerMuonCollection> >"/>
- 
  <class name="l1t::SAMuon" ClassVersion="3">
    <version ClassVersion="3" checksum="3294978731"/>
  </class>
  <class name="std::vector<l1t::SAMuon>"/>
  <class name="edm::Wrapper<std::vector<l1t::SAMuon > >"/>
  <class name="edm::Ref<l1t::SAMuonCollection>" splitLevel="0"/>
+ <class name="l1Scouting::TrackerMuon" ClassVersion="3">
+   <version ClassVersion="3" checksum="2253946675"/>
+ </class>
+ <class name="std::vector<l1Scouting::TrackerMuon>" />
+ <class name="OrbitCollection<l1Scouting::TrackerMuon>" />
+ <class name="edm::Wrapper<OrbitCollection<l1Scouting::TrackerMuon>>" />
  </selection>
 </lcgdict>

--- a/L1TriggerScouting/Phase2/interface/l1puppiUnpack.h
+++ b/L1TriggerScouting/Phase2/interface/l1puppiUnpack.h
@@ -105,6 +105,23 @@ namespace l1puppiUnpack {
     quality = pid > 1 ? (data >> 58) & 0x7 : (data >> 50) & 0x3F;
   }
 
+
+  template <unsigned int start, unsigned int bits = 16, typename T>
+     inline uint16_t extractBitsFromW(const T word) {
+    return (word >> start) & ((1 << bits) - 1);
+  }
+  template <unsigned int start, unsigned int bits = 16, typename T>
+    inline int16_t extractSignedBitsFromW(const T word) {
+    uint16_t raw = extractBitsFromW<start, bits>(word);
+    if ((bits < 16) && (raw & (1 << (bits - 1)))) {
+      constexpr uint16_t ormask = (1 << 16) - (1 << bits);
+      raw |= ormask;
+    }
+    return raw;
+  }
+
+
+
 }  // namespace l1puppiUnpack
 
 #endif

--- a/L1TriggerScouting/Phase2/interface/l1puppiUnpack.h
+++ b/L1TriggerScouting/Phase2/interface/l1puppiUnpack.h
@@ -105,13 +105,12 @@ namespace l1puppiUnpack {
     quality = pid > 1 ? (data >> 58) & 0x7 : (data >> 50) & 0x3F;
   }
 
-
   template <unsigned int start, unsigned int bits = 16, typename T>
-     inline uint16_t extractBitsFromW(const T word) {
+  inline uint16_t extractBitsFromW(const T word) {
     return (word >> start) & ((1 << bits) - 1);
   }
   template <unsigned int start, unsigned int bits = 16, typename T>
-    inline int16_t extractSignedBitsFromW(const T word) {
+  inline int16_t extractSignedBitsFromW(const T word) {
     uint16_t raw = extractBitsFromW<start, bits>(word);
     if ((bits < 16) && (raw & (1 << (bits - 1)))) {
       constexpr uint16_t ormask = (1 << 16) - (1 << bits);
@@ -119,8 +118,6 @@ namespace l1puppiUnpack {
     }
     return raw;
   }
-
-
 
 }  // namespace l1puppiUnpack
 

--- a/L1TriggerScouting/Phase2/plugins/ScPhase2TrackerMuonRawToDigi.cc
+++ b/L1TriggerScouting/Phase2/plugins/ScPhase2TrackerMuonRawToDigi.cc
@@ -1,0 +1,139 @@
+#include <memory>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/L1ScoutingRawData/interface/SDSNumbering.h"
+#include "DataFormats/L1ScoutingRawData/interface/SDSRawDataCollection.h"
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+#include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"
+#include "DataFormats/L1TMuonPhase2/interface/L1ScoutingTrackerMuon.h"
+#include "L1TriggerScouting/Phase2/interface/l1puppiUnpack.h"
+
+class ScPhase2TrackerMuonRawToDigi : public edm::stream::EDProducer<> {
+public:
+  explicit ScPhase2TrackerMuonRawToDigi(const edm::ParameterSet &);
+  ~ScPhase2TrackerMuonRawToDigi() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  //void beginStream(edm::StreamID) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  //void endStream() override;
+
+  template <typename T>
+  std::unique_ptr<OrbitCollection<T>> unpackObj(const SDSRawDataCollection &feds, std::vector<std::vector<T>> &buffer);
+
+
+  edm::EDGetTokenT<SDSRawDataCollection> rawToken_;
+  std::vector<unsigned int> fedIDs_;
+  bool doCandidate_, doStruct_;
+
+  // temporary storage
+  std::vector<std::vector<l1t::PFCandidate>> candBuffer_;
+  std::vector<std::vector<l1Scouting::TrackerMuon>> structBuffer_;
+
+  void unpackFromRaw(uint64_t wlo, uint32_t whi  , std::vector<l1Scouting::TrackerMuon> &outBuffer);
+};
+
+ScPhase2TrackerMuonRawToDigi::ScPhase2TrackerMuonRawToDigi(const edm::ParameterSet &iConfig)
+    : rawToken_(consumes<SDSRawDataCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      fedIDs_(iConfig.getParameter<std::vector<unsigned int>>("fedIDs")),
+      doCandidate_(iConfig.getParameter<bool>("runCandidateUnpacker")),
+      doStruct_(iConfig.getParameter<bool>("runStructUnpacker"))
+{      
+  if (doCandidate_) {
+    produces<OrbitCollection<l1t::PFCandidate>>();
+    candBuffer_.resize(OrbitCollection<l1t::PFCandidate>::NBX + 1);  // FIXME magic number
+  }
+  if (doStruct_) {
+    structBuffer_.resize(OrbitCollection<l1Scouting::TrackerMuon>::NBX + 1);  // FIXME magic number
+    produces<OrbitCollection<l1Scouting::TrackerMuon>>();
+  }
+}
+
+ScPhase2TrackerMuonRawToDigi::~ScPhase2TrackerMuonRawToDigi(){};
+
+void ScPhase2TrackerMuonRawToDigi::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  edm::Handle<SDSRawDataCollection> scoutingRawDataCollection;
+  iEvent.getByToken(rawToken_, scoutingRawDataCollection);
+
+  if (doStruct_) {
+    iEvent.put(unpackObj(*scoutingRawDataCollection, structBuffer_));
+  }
+}
+
+template <typename T>
+std::unique_ptr<OrbitCollection<T>> ScPhase2TrackerMuonRawToDigi::unpackObj(const SDSRawDataCollection &feds,
+                                                                      std::vector<std::vector<T>> &buffer) {
+  unsigned int ntot = 0;
+  for (auto &fedId : fedIDs_) {
+    const FEDRawData &src = feds.FEDData(fedId);
+    const uint64_t *begin = reinterpret_cast<const uint64_t *>(src.data());
+    const uint64_t *end = reinterpret_cast<const uint64_t *>(src.data() + src.size());
+    for (auto p = begin; p != end;) {
+      if ((*p) == 0)
+        continue;
+      unsigned int bx = ((*p) >> 12) & 0xFFF;
+      unsigned int nwords = (*p) & 0xFFF;
+      unsigned int nTrackerMuons = 2*nwords/3;  // tocount for the 96-bit muon words
+      ++p;
+
+      assert(bx < OrbitCollection<T>::NBX);   // asser fail --> unpacked wrong !
+      std::vector<T> &outputBuffer = buffer[bx + 1];
+      outputBuffer.reserve(nwords);
+      
+      uint64_t wlo;
+      uint32_t whi;
+
+      const uint32_t *pMu = reinterpret_cast<const uint32_t *>(p) ;
+      for (unsigned int i = 0; i < nTrackerMuons; ++i,pMu += 3 /* jumping 96bits*/) {
+          if( (i & 1)==1  )  // ODD TrackerMuons
+          {
+                wlo = *reinterpret_cast<const uint64_t *>(pMu+1) ;
+                whi = *pMu;
+          }
+          else
+          {
+                wlo = *reinterpret_cast<const uint64_t *>(pMu) ;
+                whi = *(pMu+2);
+
+          }
+        if( (wlo==0) and (whi==0)) continue;
+        unpackFromRaw(wlo,whi, outputBuffer);
+        ntot++;
+      }
+      p+=nwords;
+    }
+   }
+  return std::make_unique<OrbitCollection<T>>(buffer, ntot);
+}
+
+void ScPhase2TrackerMuonRawToDigi::unpackFromRaw(uint64_t wlo, uint32_t whi ,std::vector<l1Scouting::TrackerMuon> &outBuffer) {
+  float pt, eta, phi, z0 = 0, d0 = 0,beta;
+  int8_t charge;
+  uint8_t quality,isolation;
+  
+  pt        = l1puppiUnpack::extractBitsFromW<1, 16>(wlo) * 0.03125f;
+  phi       = l1puppiUnpack::extractSignedBitsFromW<17, 13>(wlo) * float(M_PI / (1 << 12));
+  eta       = l1puppiUnpack::extractSignedBitsFromW<30, 14>(wlo) * float(M_PI / (1 << 12));
+  z0        = l1puppiUnpack::extractSignedBitsFromW<44, 10>(wlo) * 0.05f;
+  d0        = l1puppiUnpack::extractSignedBitsFromW<54, 10>(wlo) * 0.03f;
+  quality   = l1puppiUnpack::extractBitsFromW<1, 8>(whi);
+  isolation = l1puppiUnpack::extractBitsFromW<9, 4>(whi);
+  beta      = l1puppiUnpack::extractBitsFromW<13, 4>(whi) * 0.06f;
+  charge    = (whi & 1) ? -1 : +1;
+  outBuffer.emplace_back(pt, eta, phi,  z0, d0,charge,quality,beta,isolation);
+}
+
+void ScPhase2TrackerMuonRawToDigi::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(ScPhase2TrackerMuonRawToDigi);

--- a/L1TriggerScouting/Phase2/plugins/ScPhase2TrackerMuonsDiMuDemo.cc
+++ b/L1TriggerScouting/Phase2/plugins/ScPhase2TrackerMuonsDiMuDemo.cc
@@ -36,11 +36,9 @@ private:
               unsigned long &nTry,
               unsigned long &nPass,
               const std::string &bxLabel);
-  //void runSOA(const l1Scouting::TrackerMuonSOA &src, edm::Event &out);
 
-  bool doCandidate_, doStruct_, doSOA_;
+  bool doCandidate_, doStruct_;
   edm::EDGetTokenT<OrbitCollection<l1Scouting::TrackerMuon>> structToken_;
-  //edm::EDGetTokenT<l1Scouting::TrackerMuonSOA> soaToken_;
 
   struct Cuts {
     float minptOverMass = 0.25;
@@ -52,30 +50,24 @@ private:
     float z0Max = 1.0;
   } cuts;
 
-  unsigned long countStruct_, countSOA_;
-  unsigned long passStruct_, passSOA_;
+  unsigned long countStruct_;
+  unsigned long passStruct_;
 };
 
 ScPhase2TrackerMuonDiMuDemo::ScPhase2TrackerMuonDiMuDemo(const edm::ParameterSet &iConfig)
-    : doStruct_(iConfig.getParameter<bool>("runStruct")), doSOA_(iConfig.getParameter<bool>("runSOA")) {
+    : doStruct_(iConfig.getParameter<bool>("runStruct")) {
   if (doStruct_) {
     structToken_ = consumes<OrbitCollection<l1Scouting::TrackerMuon>>(iConfig.getParameter<edm::InputTag>("src"));
     produces<std::vector<unsigned>>("selectedBx");
     produces<l1ScoutingRun3::OrbitFlatTable>("DiMu");
   }
-  //  if (doSOA_) {
-  //    soaToken_ = consumes<l1Scouting::TrackerMuonSOA>(iConfig.getParameter<edm::InputTag>("src"));
-  //    produces<l1Scouting::TrackerMuonSOA>();
-  //  }
 }
 
 ScPhase2TrackerMuonDiMuDemo::~ScPhase2TrackerMuonDiMuDemo(){};
 
 void ScPhase2TrackerMuonDiMuDemo::beginStream(edm::StreamID) {
   countStruct_ = 0;
-  countSOA_ = 0;
   passStruct_ = 0;
-  passSOA_ = 0;
 }
 
 void ScPhase2TrackerMuonDiMuDemo::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
@@ -84,18 +76,11 @@ void ScPhase2TrackerMuonDiMuDemo::produce(edm::Event &iEvent, const edm::EventSe
     iEvent.getByToken(structToken_, src);
     runObj(*src, iEvent, countStruct_, passStruct_, "");
   }
-  //  if (doSOA_) {
-  //    edm::Handle<l1Scouting::TrackerMuonSOA> src;
-  //    iEvent.getByToken(soaToken_, src);
-  //    runSOA(*src, iEvent);
-  //  }
 }
 
 void ScPhase2TrackerMuonDiMuDemo::endStream() {
   if (doStruct_)
     std::cout << "DiTrackerMuon | Struct analysis : " << countStruct_ << " -> " << passStruct_ << std::endl;
-  if (doSOA_)
-    std::cout << "DiTrackerMuon | SOA analysis    : " << countSOA_ << " -> " << passSOA_ << std::endl;
 }
 
 template <typename T>
@@ -169,9 +154,6 @@ void ScPhase2TrackerMuonDiMuDemo::runObj(const OrbitCollection<T> &src,
   tab->addColumn<uint8_t>("i1", i1s, "subleading muon");
   iEvent.put(std::move(tab), "DiMu" + label);
 }
-/*
-void ScPhase2TrackerMuonDiMuDemo::runSOA(const l1Scouting::TrackerMuonSOA &src, edm::Event &iEvent) {}
-*/
 
 void ScPhase2TrackerMuonDiMuDemo::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;

--- a/L1TriggerScouting/Phase2/plugins/ScPhase2TrackerMuonsDiMuDemo.cc
+++ b/L1TriggerScouting/Phase2/plugins/ScPhase2TrackerMuonsDiMuDemo.cc
@@ -1,0 +1,172 @@
+#include <memory>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+#include "DataFormats/L1Scouting/interface/OrbitFlatTable.h"
+#include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"
+#include "DataFormats/L1TMuonPhase2/interface/L1ScoutingTrackerMuon.h"
+#include "L1TriggerScouting/Utilities/interface/BxOffsetsFiller.h"
+
+#include <ROOT/RVec.hxx>
+#include <Math/Vector4D.h>
+#include <Math/GenVector/LorentzVector.h>
+#include <Math/GenVector/PtEtaPhiM4D.h>
+#include <algorithm>
+#include <array>
+#include <iostream>
+
+class ScPhase2TrackerMuonDiMuDemo : public edm::stream::EDProducer<> {
+public:
+  explicit ScPhase2TrackerMuonDiMuDemo(const edm::ParameterSet &);
+  ~ScPhase2TrackerMuonDiMuDemo() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  void beginStream(edm::StreamID) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  void endStream() override;
+  template <typename T>
+  void runObj(const OrbitCollection<T> &src,
+              edm::Event &out,
+              unsigned long &nTry,
+              unsigned long &nPass,
+              const std::string &bxLabel);
+  //void runSOA(const l1Scouting::TrackerMuonSOA &src, edm::Event &out);
+
+  bool doCandidate_, doStruct_, doSOA_;
+  edm::EDGetTokenT<OrbitCollection<l1Scouting::TrackerMuon>> structToken_;
+  //edm::EDGetTokenT<l1Scouting::TrackerMuonSOA> soaToken_;
+
+  struct Cuts {
+    float minptOverMass = 0.25;  
+    float qualityMin = 75;
+    float massMin = 7.0 ;   //  after b's
+    bool  doOppsiteCharge = true;
+    float etaMax = 2.0;
+    float ptMin = 2.0; 
+    float z0Max = 1.0;
+  } cuts;
+
+  unsigned long countStruct_, countSOA_;
+  unsigned long passStruct_, passSOA_;
+};
+
+ScPhase2TrackerMuonDiMuDemo::ScPhase2TrackerMuonDiMuDemo(const edm::ParameterSet &iConfig)
+    : doStruct_(iConfig.getParameter<bool>("runStruct")),
+      doSOA_(iConfig.getParameter<bool>("runSOA")) {
+
+  if (doStruct_) {
+    structToken_ = consumes<OrbitCollection<l1Scouting::TrackerMuon>>(iConfig.getParameter<edm::InputTag>("src"));
+    produces<std::vector<unsigned>>("selectedBx");
+    produces<l1ScoutingRun3::OrbitFlatTable>("DiMu");
+  }
+//  if (doSOA_) {
+//    soaToken_ = consumes<l1Scouting::TrackerMuonSOA>(iConfig.getParameter<edm::InputTag>("src"));
+//    produces<l1Scouting::TrackerMuonSOA>();
+//  }
+}
+
+ScPhase2TrackerMuonDiMuDemo::~ScPhase2TrackerMuonDiMuDemo(){};
+
+void ScPhase2TrackerMuonDiMuDemo::beginStream(edm::StreamID) {
+  countStruct_ = 0;
+  countSOA_ = 0;
+  passStruct_ = 0;
+  passSOA_ = 0;
+}
+
+void ScPhase2TrackerMuonDiMuDemo::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+
+  if (doStruct_) {
+    edm::Handle<OrbitCollection<l1Scouting::TrackerMuon>> src;
+    iEvent.getByToken(structToken_, src);
+    runObj(*src, iEvent, countStruct_, passStruct_, "");
+  }
+//  if (doSOA_) {
+//    edm::Handle<l1Scouting::TrackerMuonSOA> src;
+//    iEvent.getByToken(soaToken_, src);
+//    runSOA(*src, iEvent);
+//  }
+}
+
+void ScPhase2TrackerMuonDiMuDemo::endStream() {
+  if (doStruct_)
+    std::cout << "DiTrackerMuon | Struct analysis : " << countStruct_ << " -> " << passStruct_ << std::endl;
+  if (doSOA_)
+    std::cout << "DiTrackerMuon | SOA analysis    : " << countSOA_    << " -> " << passSOA_    << std::endl;
+}
+
+template <typename T>
+void ScPhase2TrackerMuonDiMuDemo::runObj(const OrbitCollection<T> &src,
+                                   edm::Event &iEvent,
+                                   unsigned long &nTry,
+                                   unsigned long &nPass,
+                                   const std::string &label) {
+  l1ScoutingRun3::BxOffsetsFillter bxOffsetsFiller;
+  bxOffsetsFiller.start();
+  auto selectedBx_idx = std::make_unique<std::vector<unsigned>>();
+  float mass;
+  std::vector<float> masses;
+  std::vector<uint8_t> i0s, i1s;
+  for (unsigned int bx = 1; bx <= OrbitCollection<T>::NBX; ++bx) {
+    nTry++;
+    auto range = src.bxIterator(bx);
+    const T *cands = &range.front();
+    auto size = range.size();
+    bool hasCandidate=false;
+    for (unsigned int i = 0; i < size; ++i) { 
+        if(    cands[i].pt()   <  cuts.ptMin  ) break; // assumes pt ordering
+        if(    cands[i].z0()        > cuts.z0Max ) continue;
+        if(abs(cands[i].eta())      > cuts.etaMax ) continue;
+        if(    cands[i].quality()   < cuts.qualityMin  ) continue;
+       // if(    cands[i].isolation()   > XX  ) continue;
+    
+        for (unsigned int j = i+1; j < size; ++j) { 
+            if(    cands[j].pt()   <  cuts.ptMin  ) break; // assumes pt ordering
+            if( cuts.doOppsiteCharge and ( cands[i].charge() * cands[j].charge() >0 )  )  continue;
+            if(    abs(cands[j].z0())   > cuts.z0Max  ) continue;
+            if(abs(cands[j].eta())      > cuts.etaMax ) continue;
+            if(    cands[j].quality()   < cuts.qualityMin  ) continue;
+      //      if(    cands[j].isolation()   > YY  ) continue;
+            
+            mass = (cands[i].p4() + cands[j].p4()).mass() ;
+            if( mass < cuts.massMin ) continue;
+            if( cands[j].pt() < cuts.minptOverMass * mass) continue;
+            if( cands[i].pt() < cuts.minptOverMass * mass) continue;
+            selectedBx_idx->emplace_back(bx);
+            masses.push_back(mass);
+            i0s.push_back(i);
+            i1s.push_back(j);
+            bxOffsetsFiller.addBx(bx, 1);
+            hasCandidate=true;
+         }    
+      }
+
+      if (hasCandidate) nPass++;
+  }  // loop on BXs
+
+  iEvent.put(std::move(selectedBx_idx), "selectedBx" + label);
+  // now we make the table
+  auto bxOffsets = bxOffsetsFiller.done();
+  auto tab = std::make_unique<l1ScoutingRun3::OrbitFlatTable>(bxOffsets, "DiMu" + label, true);
+  tab->addColumn<float>("mass", masses, "Dimuon invariant mass");
+  tab->addColumn<uint8_t>("i0", i0s, "leading muon");
+  tab->addColumn<uint8_t>("i1", i1s, "subleading muon");
+  iEvent.put(std::move(tab), "DiMu" + label);
+}
+/*
+void ScPhase2TrackerMuonDiMuDemo::runSOA(const l1Scouting::TrackerMuonSOA &src, edm::Event &iEvent) {}
+*/
+
+void ScPhase2TrackerMuonDiMuDemo::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(ScPhase2TrackerMuonDiMuDemo);

--- a/L1TriggerScouting/Phase2/plugins/ScTrackerMuonToOrbitFlatTable.cc
+++ b/L1TriggerScouting/Phase2/plugins/ScTrackerMuonToOrbitFlatTable.cc
@@ -50,25 +50,25 @@ ScTrackerMuonToOrbitFlatTable::ScTrackerMuonToOrbitFlatTable(const edm::Paramete
 
 // ----------------------- method called for each orbit  -----------------------
 void ScTrackerMuonToOrbitFlatTable::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
-  
   edm::Handle<OrbitCollection<l1Scouting::TrackerMuon>> src;
   iEvent.getByToken(src_, src);
-  
+
   auto out = std::make_unique<l1ScoutingRun3::OrbitFlatTable>(src->bxOffsets(), name_);
   out->setDoc(doc_);
-  std::vector<float> pt(out->size()), eta(out->size()), phi(out->size()), z0(out->size()), d0(out->size()),beta(out->size());
-  std::vector<uint8_t> quality(out->size()),isolation(out->size());
-  std::vector<int32_t>  charge(out->size());
+  std::vector<float> pt(out->size()), eta(out->size()), phi(out->size()), z0(out->size()), d0(out->size()),
+      beta(out->size());
+  std::vector<uint8_t> quality(out->size()), isolation(out->size());
+  std::vector<int32_t> charge(out->size());
   unsigned int i = 0;
   for (const l1Scouting::TrackerMuon& muon : *src) {
-    pt[i]      = muon.pt();
-    eta[i]     = muon.eta();
-    phi[i]     = muon.phi();
-    z0[i]      = muon.z0();
-    d0[i]      = muon.d0();
+    pt[i] = muon.pt();
+    eta[i] = muon.eta();
+    phi[i] = muon.phi();
+    z0[i] = muon.z0();
+    d0[i] = muon.d0();
     quality[i] = muon.quality();
     isolation[i] = muon.isolation();
-    charge[i]  = muon.charge();
+    charge[i] = muon.charge();
     ++i;
   }
 
@@ -79,7 +79,7 @@ void ScTrackerMuonToOrbitFlatTable::produce(edm::StreamID, edm::Event& iEvent, e
   out->addColumn<float>("d0", d0, "d0 (cm)");
   out->addColumn<int32_t>("charge", charge, "charge (+1/-1)");
   out->addColumn<uint8_t>("isolation", isolation, "isolation (8 bits");
-  out->addColumn<uint8_t>("quality",quality, "quality (8 bits");
+  out->addColumn<uint8_t>("quality", quality, "quality (8 bits");
   iEvent.put(std::move(out));
 }
 

--- a/L1TriggerScouting/Phase2/plugins/ScTrackerMuonToOrbitFlatTable.cc
+++ b/L1TriggerScouting/Phase2/plugins/ScTrackerMuonToOrbitFlatTable.cc
@@ -1,0 +1,96 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include <fstream>
+#include <iomanip>
+#include <memory>
+#include <string>
+#include <cmath>
+
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/MessageLogger/interface/MessageDrop.h"
+
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+#include "DataFormats/L1TMuonPhase2/interface/L1ScoutingTrackerMuon.h"
+#include "DataFormats/L1Scouting/interface/OrbitFlatTable.h"
+
+class ScTrackerMuonToOrbitFlatTable : public edm::global::EDProducer<> {
+public:
+  // constructor and destructor
+  explicit ScTrackerMuonToOrbitFlatTable(const edm::ParameterSet&);
+  ~ScTrackerMuonToOrbitFlatTable() override{};
+
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  // the tokens to access the data
+  edm::EDGetTokenT<OrbitCollection<l1Scouting::TrackerMuon>> src_;
+
+  std::string name_, doc_;
+};
+// -----------------------------------------------------------------------------
+
+// -------------------------------- constructor  -------------------------------
+
+ScTrackerMuonToOrbitFlatTable::ScTrackerMuonToOrbitFlatTable(const edm::ParameterSet& iConfig)
+    : src_(consumes<OrbitCollection<l1Scouting::TrackerMuon>>(iConfig.getParameter<edm::InputTag>("src"))),
+      name_(iConfig.getParameter<std::string>("name")),
+      doc_(iConfig.getParameter<std::string>("doc")) {
+  produces<l1ScoutingRun3::OrbitFlatTable>();
+}
+// -----------------------------------------------------------------------------
+
+// ----------------------- method called for each orbit  -----------------------
+void ScTrackerMuonToOrbitFlatTable::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
+  
+  edm::Handle<OrbitCollection<l1Scouting::TrackerMuon>> src;
+  iEvent.getByToken(src_, src);
+  
+  auto out = std::make_unique<l1ScoutingRun3::OrbitFlatTable>(src->bxOffsets(), name_);
+  out->setDoc(doc_);
+  std::vector<float> pt(out->size()), eta(out->size()), phi(out->size()), z0(out->size()), d0(out->size()),beta(out->size());
+  std::vector<uint8_t> quality(out->size()),isolation(out->size());
+  std::vector<int32_t>  charge(out->size());
+  unsigned int i = 0;
+  for (const l1Scouting::TrackerMuon& muon : *src) {
+    pt[i]      = muon.pt();
+    eta[i]     = muon.eta();
+    phi[i]     = muon.phi();
+    z0[i]      = muon.z0();
+    d0[i]      = muon.d0();
+    quality[i] = muon.quality();
+    isolation[i] = muon.isolation();
+    charge[i]  = muon.charge();
+    ++i;
+  }
+
+  out->addColumn<float>("pt", pt, "pt (GeV)");
+  out->addColumn<float>("eta", eta, "eta (natural units)");
+  out->addColumn<float>("phi", phi, "phi (natural units)");
+  out->addColumn<float>("z0", z0, "z0 (cm)");
+  out->addColumn<float>("d0", d0, "d0 (cm)");
+  out->addColumn<int32_t>("charge", charge, "charge (+1/-1)");
+  out->addColumn<uint8_t>("isolation", isolation, "isolation (8 bits");
+  out->addColumn<uint8_t>("quality",quality, "quality (8 bits");
+  iEvent.put(std::move(out));
+}
+
+void ScTrackerMuonToOrbitFlatTable::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("src");
+  desc.add<std::string>("name");
+  desc.add<std::string>("doc");
+
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(ScTrackerMuonToOrbitFlatTable);

--- a/L1TriggerScouting/Phase2/test/runScoutingPhase2_cfg.py
+++ b/L1TriggerScouting/Phase2/test/runScoutingPhase2_cfg.py
@@ -58,7 +58,7 @@ options.register ('numFwkStreams',
                   VarParsing.VarParsing.varType.int,          # string, int, or float
                   "Number of CMSSW streams")
 
-options.register ('puppiMode',
+options.register ('mode',
                   'simple', # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,          # string, int, or float
@@ -75,10 +75,15 @@ options.register ('outFile',
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
                   "Sub lumisection number to process")
+options.register ('doTkTrackerMuons',
+                  1, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.bool,          # string, int, or float
+                  "Process tkTrackerMuon paths")
 
 
 options.parseArguments()
-if options.puppiMode not in ("simple", "sparse", "struct", "sparseStruct", "soa", "all", "fast"):
+if options.mode not in ("simple", "sparse", "struct", "sparseStruct", "soa", "all", "fast"):
     raise RuntimeError("Unsupported puppiMode %r" %options.puppiMode)
 
 cmsswbase = os.path.expandvars("$CMSSW_BASE/")
@@ -109,6 +114,7 @@ process.EvFDaqDirector = cms.Service("EvFDaqDirector",
     directorIsBU = cms.untracked.bool(False),
 )
 
+print(process.EvFDaqDirector.buBaseDirsNumStreams)
 fuDir = options.fuBaseDir+("/run%06d" % options.runNumber)
 buDirs = [b+("/run%06d" % options.runNumber) for b in options.buBaseDir]
 for d in [fuDir, options.fuBaseDir] + buDirs + options.buBaseDir:
@@ -127,9 +133,10 @@ process.source = cms.Source("DAQSource",
     maxBufferedFiles = cms.untracked.uint32(4),
     fileListMode = cms.untracked.bool(True),
     fileNames = cms.untracked.vstring(
-        buDirs[0] + "/" + "run%06d_ls%04d_index%06d_stream00.raw" % (options.runNumber, options.lumiNumber, 1),
+        buDirs[0] + "/" + "run%06d_ls%04d_index%06d_stream00.raw" % (options.runNumber, options.lumiNumber, 1)
     )
 )
+
 os.system("touch " + buDirs[0] + "/" + "fu.lock")
 
 ## test pluging
@@ -174,14 +181,41 @@ process.scPhase2PuppiStructToTable = cms.EDProducer("ScPuppiToOrbitFlatTable",
     name = cms.string("L1Puppi"),
     doc = cms.string("L1Puppi candidates from Correlator Layer 2"),
 )
+
+scPhase2TrackerMuonRawToDigi = cms.EDProducer('ScPhase2TrackerMuonRawToDigi',
+  src = cms.InputTag('rawDataCollector'),
+  fedIDs = cms.vuint32(0),
+  runCandidateUnpacker = cms.bool(False),
+  runStructUnpacker = cms.bool(False),
+  runSOAUnpacker = cms.bool(False),
+)
+process.scPhase2TrackerMuonRawToDigiStruct = scPhase2TrackerMuonRawToDigi.clone(
+    fedIDs = cms.vuint32(1),
+    runStructUnpacker = True
+)
+process.scPhase2TrackerMuonStructToTable = cms.EDProducer("ScTrackerMuonToOrbitFlatTable",
+    src = cms.InputTag("scPhase2TrackerMuonRawToDigiStruct"),
+    name = cms.string("L1TrackerMuon"),
+    doc = cms.string("L1TrackerMuon candidates from Correlator Layer 2"),
+)
+process.dimuStruct = cms.EDProducer("ScPhase2TrackerMuonDiMuDemo",
+    src = cms.InputTag("scPhase2TrackerMuonRawToDigiStruct"),
+    runCandidate = cms.bool(False),
+    runStruct = cms.bool(True),
+    runSOA = cms.bool(False)
+)
+
 process.p_simple = cms.Path(
   process.scPhase2PuppiRawToDigiCandidate
   +process.w3piCandidate
 )
 process.p_struct = cms.Path(
   process.scPhase2PuppiRawToDigiStruct
+  +process.scPhase2TrackerMuonRawToDigiStruct
   +process.w3piStruct
+  +process.dimuStruct
   +process.scPhase2PuppiStructToTable
+  +process.scPhase2TrackerMuonStructToTable
 )
 process.p_soa = cms.Path(
   process.scPhase2PuppiRawToDigiSOA
@@ -190,18 +224,25 @@ process.p_soa = cms.Path(
 process.p_all = cms.Path(
   process.scPhase2PuppiRawToDigiCandidate+
   process.scPhase2PuppiRawToDigiStruct+
+  process.scPhase2TrackerMuonRawToDigiStruct+
   process.scPhase2PuppiRawToDigiSOA+
   process.scPhase2PuppiStructToTable+
+  process.scPhase2TrackerMuonStructToTable+
   process.w3piCandidate+
   process.w3piStruct+
-  process.w3piSOA
+  process.w3piSOA+
+  process.dimuStruct
 )
 process.p_fast = cms.Path(
   process.scPhase2PuppiRawToDigiStruct+
+  process.scPhase2TrackerMuonRawToDigiStruct+
   process.scPhase2PuppiRawToDigiSOA+
   process.scPhase2PuppiStructToTable+
+  process.scPhase2TrackerMuonStructToTable+
   process.w3piStruct+
-  process.w3piSOA
+  process.w3piSOA+
+  process.dimuStruct
+
 )
 process.scPhase2PuppiStructNanoAll = cms.OutputModule("OrbitNanoAODOutputModule",
     fileName = cms.untracked.string(options.outFile),
@@ -219,9 +260,32 @@ process.scPhase2PuppiStructNanoW3pi = cms.OutputModule("OrbitNanoAODOutputModule
     compressionLevel = cms.untracked.int32(4),
     compressionAlgorithm = cms.untracked.string("LZ4"),
 )
-process.o_structAll = cms.EndPath( process.scPhase2PuppiStructNanoAll )
+
+process.scPhase2TrackerMuonStructNanoAll = cms.OutputModule("OrbitNanoAODOutputModule",
+    fileName = cms.untracked.string(options.outFile.replace(".root","")+".tkMu.root"),
+    outputCommands = cms.untracked.vstring("drop *", "keep l1ScoutingRun3OrbitFlatTable_scPhase2TrackerMuonStructToTable_*_*"),
+    compressionLevel = cms.untracked.int32(4),
+    compressionAlgorithm = cms.untracked.string("LZ4"),
+)
+
+process.scPhase2TrackerMuonStructNanoDiMu = cms.OutputModule("OrbitNanoAODOutputModule",
+    fileName = cms.untracked.string(options.outFile.replace(".root","")+".dimu.root"),
+    selectedBx = cms.InputTag("dimuStruct","selectedBx"),
+    outputCommands = cms.untracked.vstring("drop *", 
+        "keep l1ScoutingRun3OrbitFlatTable_scPhase2TrackerMuonStructToTable_*_*",
+        "keep l1ScoutingRun3OrbitFlatTable_dimuStruct_*_*"
+        ),
+    compressionLevel = cms.untracked.int32(4),
+    compressionAlgorithm = cms.untracked.string("LZ4"),
+)
+
+process.o_structAll  = cms.EndPath( process.scPhase2PuppiStructNanoAll + process.scPhase2TrackerMuonStructNanoAll )
 process.o_structW3pi = cms.EndPath( process.scPhase2PuppiStructNanoW3pi )
-sched = [ getattr(process, "p_"+options.puppiMode) ]
+process.o_structDiMu = cms.EndPath( process.scPhase2TrackerMuonStructNanoDiMu )
+
+sched = [ getattr(process, "p_"+options.mode) ]
 if options.outMode != "none":
-  sched.append(getattr(process, "o_"+options.outMode))
+    for mode in options.outMode.split(","):
+        sched.append(getattr(process, "o_"+mode))
+
 process.schedule = cms.Schedule(*sched)

--- a/L1TriggerScouting/Phase2/test/runScoutingPhase2_cfg.py
+++ b/L1TriggerScouting/Phase2/test/runScoutingPhase2_cfg.py
@@ -287,5 +287,5 @@ sched = [ getattr(process, "p_"+options.mode) ]
 if options.outMode != "none":
     for mode in options.outMode.split(","):
         sched.append(getattr(process, "o_"+mode))
-
 process.schedule = cms.Schedule(*sched)
+


### PR DESCRIPTION
* Adds the dataformats/plugins and flat table producer codes for TkMuons for scouting in phase 2.
* The Analyzer stores the events with with dimuons

Sample test setup in `lxplus`
```
## MAKE USE of RAM_DISK
mkdir -p  /run/user/$UID/raw/run000037/
mkdir -p  /run/user/$UID/raw-tkmu/run000037/

## Make inputs
apptainer exec -B /eos -B  /run/user/$UID docker://gitlab-registry.cern.ch/scouting-demonstrator/phase-2/simple-clients/el8-minimal:2.0 p2scout-generator CMSSW /eos/cms/store/cmst3/group/l1tr/gpetrucc/l1scout/binaries/puppi_TTbar_PU200.125X_v1.0.dump  /run/user/$UID/raw/run000037/run000037_ls0001_index000001_stream00.raw --orbits 1000 -T 1
apptainer exec -B /eos -B  /run/user/$UID docker://gitlab-registry.cern.ch/scouting-demonstrator/phase-2/simple-clients/el8-minimal:2.0 p2scout-generator CMSSW /eos/cms/store/cmst3/group/l1tr/gpetrucc/l1scout/binaries/tkMuons_TTbar_PU200.125X_v1.0.dump  /run/user/$UID/raw-tkmu/run000037/run000037_ls0001_index000001_stream01.raw --orbits 1000 -T 1

cd $CMSSW_BASE/src/L1TriggerScouting/Phase2/test
cmsRun runScoutingPhase2_cfg.py buBaseDir=/run/user/$UID/raw,/run/user/$UID/raw-tkmu buNumStreams=2 mode=all outMode=structW3pi,structDiMu outFile=/run/user/$UID/output.root maxEvents=100

```