### PR TITLE
Update H analyses selections

### DIFF
--- a/L1TriggerScouting/Phase2/plugins/ScPhase2PuppiH2PhiDemo.cc
+++ b/L1TriggerScouting/Phase2/plugins/ScPhase2PuppiH2PhiDemo.cc
@@ -41,8 +41,8 @@ private:
   edm::EDGetTokenT<OrbitCollection<l1Scouting::Puppi>> structToken_;
 
   struct Cuts {
-    float minptD = 5;
-    float minptQ = 10;
+    float minptD = 10;
+    float minptQ = 30;
     float maxdeltarD2 = 0.40 * 0.40;
     float minmassH = 100;
     float maxmassH = 150;

--- a/L1TriggerScouting/Phase2/plugins/ScPhase2PuppiH2RhoDemo.cc
+++ b/L1TriggerScouting/Phase2/plugins/ScPhase2PuppiH2RhoDemo.cc
@@ -41,8 +41,8 @@ private:
   edm::EDGetTokenT<OrbitCollection<l1Scouting::Puppi>> structToken_;
 
   struct Cuts {
-    float minptD = 5;
-    float minptQ = 10;
+    float minptD = 10;
+    float minptQ = 30;
     float maxdeltarD2 = 0.40 * 0.40;
     float minmassH = 100;
     float maxmassH = 150;

--- a/L1TriggerScouting/Phase2/plugins/ScPhase2PuppiHJPsiGammaDemo.cc
+++ b/L1TriggerScouting/Phase2/plugins/ScPhase2PuppiHJPsiGammaDemo.cc
@@ -43,10 +43,10 @@ private:
   edm::EDGetTokenT<OrbitCollection<l1Scouting::TkEm>> structTkEmToken_;
 
   struct Cuts {
-    float minpt1 = 5;
-    float minpt2 = 5;
-    float minpt3 = 10;
-    float minptQ = 10;
+    float minpt1 = 10;
+    float minpt2 = 10;
+    float minpt3 = 30;
+    float minptQ = 30;
     float maxdeltar2 = 0.40 * 0.40;
     float minmass = 100;
     float maxmass = 150;

--- a/L1TriggerScouting/Phase2/plugins/ScPhase2PuppiHPhiGammaDemo.cc
+++ b/L1TriggerScouting/Phase2/plugins/ScPhase2PuppiHPhiGammaDemo.cc
@@ -43,10 +43,10 @@ private:
   edm::EDGetTokenT<OrbitCollection<l1Scouting::TkEm>> structTkEmToken_;
 
   struct Cuts {
-    float minpt1 = 5;
-    float minpt2 = 5;
-    float minpt3 = 10;
-    float minptQ = 10;
+    float minpt1 = 10;
+    float minpt2 = 10;
+    float minpt3 = 30;
+    float minptQ = 30;
     float maxdeltar2 = 0.40 * 0.40;
     float minmass = 100;
     float maxmass = 150;

--- a/L1TriggerScouting/Phase2/plugins/ScPhase2PuppiHPhiJPsiDemo.cc
+++ b/L1TriggerScouting/Phase2/plugins/ScPhase2PuppiHPhiJPsiDemo.cc
@@ -41,8 +41,8 @@ private:
   edm::EDGetTokenT<OrbitCollection<l1Scouting::Puppi>> structToken_;
 
   struct Cuts {
-    float minptD = 5;
-    float minptQ = 10;
+    float minptD = 10;
+    float minptQ = 30;
     float maxdeltarD2 = 0.40 * 0.40;
     float minmassH = 100;
     float maxmassH = 150;

--- a/L1TriggerScouting/Phase2/plugins/ScPhase2PuppiHRhoGammaDemo.cc
+++ b/L1TriggerScouting/Phase2/plugins/ScPhase2PuppiHRhoGammaDemo.cc
@@ -43,10 +43,10 @@ private:
   edm::EDGetTokenT<OrbitCollection<l1Scouting::TkEm>> structTkEmToken_;
 
   struct Cuts {
-    float minpt1 = 5;
-    float minpt2 = 5;
-    float minpt3 = 10;
-    float minptQ = 10;
+    float minpt1 = 10;
+    float minpt2 = 10;
+    float minpt3 = 30;
+    float minptQ = 30;
     float maxdeltar2 = 0.40 * 0.40;
     float minmass = 100;
     float maxmass = 150;


### PR DESCRIPTION
This PR changes the cuts for the H rare decays analyses to the final selections (pT tracks >= 10 GeV, pT Q >= 30 GeV, pT photon >= 30 GeV)